### PR TITLE
several fixes in error handling and connect flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ await client.connect();
 Subscribe to channel:
 ```dart
 final subscription = client.getSubscription(channel);
-await subscription.subscribe();
 
 subscription.publishStream.listen(onEvent);
 subscription.joinStream.listen(onEvent);  
 subscription.leaveStream.listen(onEvent);
-
 subscription.subscribeSuccessStream.listen(onEvent);
 subscription.subscribeErrorStream.listen(onEvent);
 subscription.unsubscribeStream.listen(onEvent);
+
+await subscription.subscribe();
 ```
 Subscribe to private channel:
 ```dart

--- a/example/console/readme.md
+++ b/example/console/readme.md
@@ -1,0 +1,7 @@
+Before running example make sure you allowed publishing into channel in Centrifugo configurtion.
+
+Or alternatively run Centrifugo in insecure client mode:
+
+```bash
+./centrifugo --config config.json --client_insecure
+```

--- a/example/console/simple.dart
+++ b/example/console/simple.dart
@@ -5,7 +5,7 @@ import 'package:centrifuge/centrifuge.dart' as centrifuge;
 
 void main() async {
   final url = 'ws://localhost:8000/connection/websocket?format=protobuf';
-  final channel = 'chat';
+  final channel = 'chat:index';
 
   final onEvent = (dynamic event) {
     print('$channel> $event');
@@ -22,10 +22,11 @@ void main() async {
     client.connectStream.listen(onEvent);
     client.disconnectStream.listen(onEvent);
 
+    // Uncomment to use example token based on secret key `secret`.
+    // client.setToken('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3VpdGVfand0In0.hPmHsVqvtY88PvK4EmJlcdwNuKFuy3BGaF7dMaKdPlw');
     await client.connect();
 
     final subscription = client.getSubscription(channel);
-    await subscription.subscribe();
 
     subscription.publishStream.map((e) => utf8.decode(e.data)).listen(onEvent);
     subscription.joinStream.listen(onEvent);
@@ -34,6 +35,8 @@ void main() async {
     subscription.subscribeSuccessStream.listen(onEvent);
     subscription.subscribeErrorStream.listen(onEvent);
     subscription.unsubscribeStream.listen(onEvent);
+
+    await subscription.subscribe();
 
     final handler = _handleUserInput(client, subscription);
 

--- a/example/flutter_app/lib/main.dart
+++ b/example/flutter_app/lib/main.dart
@@ -96,7 +96,6 @@ class _MyHomePageState extends State<MyHomePage> {
   void _subscribe() async {
     final channel = 'chat:index';
     _subscription = _centrifuge.getSubscription(channel);
-    await _subscription.subscribe();
 
     _subscription.subscribeErrorStream.listen(_show);
     _subscription.subscribeSuccessStream.listen(_show);
@@ -135,6 +134,8 @@ class _MyHomePageState extends State<MyHomePage> {
       final item = _ChatItem(title: message, subtitle: 'User: user');
       onNewItem(item);
     });
+
+    await _subscription.subscribe();
   }
 
   void _show(dynamic error) {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -165,7 +165,7 @@ class ClientImpl implements Client, GeneratedMessageSender {
               Req request, Rep result) =>
           _transport.sendMessage(request, result);
 
-  int _retryCount;
+  int _retryCount = 0;
 
   void _processDisconnect({@required String reason, bool reconnect}) async {
     if (_state == _ClientState.disconnected) {
@@ -181,7 +181,6 @@ class ClientImpl implements Client, GeneratedMessageSender {
 
     if (reconnect) {
       _state = _ClientState.connecting;
-
       _retryCount += 1;
       await _config.retry(_retryCount);
       _connect();

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -135,8 +135,8 @@ class SubscribeErrorEvent {
   final String message;
   final int code;
 
-  static SubscribeErrorEvent from(proto.Error error) =>
-      SubscribeErrorEvent(error.message, error.code);
+  static SubscribeErrorEvent from(int code, String message) =>
+      SubscribeErrorEvent(message, code);
 
   @override
   String toString() {

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -135,9 +135,6 @@ class SubscribeErrorEvent {
   final String message;
   final int code;
 
-  static SubscribeErrorEvent from(int code, String message) =>
-      SubscribeErrorEvent(message, code);
-
   @override
   String toString() {
     return 'SubscribeErrorEvent{message: $message, code: $code}';

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import 'client.dart';
+import 'error.dart' as errors;
 import 'events.dart';
 import 'proto/client.pb.dart';
 
@@ -138,8 +139,8 @@ class SubscriptionImpl implements Subscription {
       _onSubscribeSuccess(event);
       _recover(result);
     } catch (exception) {
-      if (exception is Error) {
-        _onSubscribeError(SubscribeErrorEvent.from(exception));
+      if (exception is errors.Error) {
+        _onSubscribeError(SubscribeErrorEvent.from(exception.code, exception.message));
       } else {
         _onSubscribeError(SubscribeErrorEvent(exception.toString(), -1));
       }

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -140,7 +140,8 @@ class SubscriptionImpl implements Subscription {
       _recover(result);
     } catch (exception) {
       if (exception is errors.Error) {
-        _onSubscribeError(SubscribeErrorEvent.from(exception.code, exception.message));
+        _onSubscribeError(
+            SubscribeErrorEvent.from(exception.code, exception.message));
       } else {
         _onSubscribeError(SubscribeErrorEvent(exception.toString(), -1));
       }

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -141,7 +141,7 @@ class SubscriptionImpl implements Subscription {
     } catch (exception) {
       if (exception is errors.Error) {
         _onSubscribeError(
-            SubscribeErrorEvent.from(exception.code, exception.message));
+            SubscribeErrorEvent(exception.message, exception.code));
       } else {
         _onSubscribeError(SubscribeErrorEvent(exception.toString(), -1));
       }

--- a/lib/src/transport.dart
+++ b/lib/src/transport.dart
@@ -23,9 +23,9 @@ Transport protobufTransportBuilder(
 
   final transport = Transport(
     () => WebSocket.connect(
-          url,
-          headers: headers,
-        ),
+      url,
+      headers: headers,
+    ),
     commandEncoder,
     replyDecoder,
   );


### PR DESCRIPTION
Fixes:
* null pointer dereference on connect to a non-working server
* wrong subscribe error type checking - without this fix the error was `SubscribeErrorEvent{message: Error{code: 103, message: permission denied}, code: -1}`, now it's `SubscribeErrorEvent{message: permission denied, code: 103}`
* better console example - fixes lack of `SubscribeSuccessEvent`