### PR TITLE
Private channel subscription and connection flow fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note that `?format=protobuf` is required because this library only works with Pr
 
 Connect to server:
 ```dart
-await client.connect();
+client.connect();
 ```
 Subscribe to channel:
 ```dart
@@ -34,7 +34,7 @@ subscription.subscribeSuccessStream.listen(onEvent);
 subscription.subscribeErrorStream.listen(onEvent);
 subscription.unsubscribeStream.listen(onEvent);
 
-await subscription.subscribe();
+subscription.subscribe();
 ```
 
 Publish:

--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ subscription.unsubscribeStream.listen(onEvent);
 
 await subscription.subscribe();
 ```
-Subscribe to private channel:
-```dart
-final privateSubscription = client.subscribe(channel, token: 'token');
-```
 Publish:
 ```dart
 final output = jsonEncode({'input': message});
@@ -70,7 +66,7 @@ await subscription.publish(data);
 - [x] handle asynchronous messages from server
 - [x] send RPC commands
 - [x] publish to channel without being subscribed
-- [ ] subscribe to private channels with JWT
+- [x] subscribe to private channels with JWT
 - [ ] connection JWT refresh
 - [ ] private channel subscription JWT refresh
 - [ ] handle connection expired error

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ await client.connect();
 Subscribe to channel:
 ```dart
 final subscription = client.getSubscription(channel);
-await subscription.subscribe();
 
 subscription.publishStream.listen(onEvent);
 subscription.joinStream.listen(onEvent);  
 subscription.leaveStream.listen(onEvent);
-
 subscription.subscribeSuccessStream.listen(onEvent);
 subscription.subscribeErrorStream.listen(onEvent);
 subscription.unsubscribeStream.listen(onEvent);
+
+await subscription.subscribe();
 ```
 Subscribe to private channel:
 ```dart

--- a/example/console/readme.md
+++ b/example/console/readme.md
@@ -1,0 +1,7 @@
+Before running example make sure you allowed publishing into channel in Centrifugo configurtion.
+
+Or alternatively run Centrifugo in insecure client mode:
+
+```bash
+./centrifugo --config config.json --client_insecure
+```

--- a/example/console/simple.dart
+++ b/example/console/simple.dart
@@ -15,11 +15,10 @@ void main() async {
     final client = centrifuge.createClient(
       url,
       config: centrifuge.ClientConfig(
-        headers: <String, dynamic>{'user-id': 42, 'user-name': 'The Answer'},
-        onPrivateSub: (centrifuge.PrivateSubEvent event) {
-          return '<SUBSCRIPTION JWT>';
-        }
-      ),
+          headers: <String, dynamic>{'user-id': 42, 'user-name': 'The Answer'},
+          onPrivateSub: (centrifuge.PrivateSubEvent event) {
+            return '<SUBSCRIPTION JWT>';
+          }),
     );
 
     client.connectStream.listen(onEvent);

--- a/example/console/simple.dart
+++ b/example/console/simple.dart
@@ -5,7 +5,7 @@ import 'package:centrifuge/centrifuge.dart' as centrifuge;
 
 void main() async {
   final url = 'ws://localhost:8000/connection/websocket?format=protobuf';
-  final channel = 'chat';
+  final channel = 'chat:index';
 
   final onEvent = (dynamic event) {
     print('$channel> $event');
@@ -22,10 +22,11 @@ void main() async {
     client.connectStream.listen(onEvent);
     client.disconnectStream.listen(onEvent);
 
+    // Uncomment to use example token based on secret key `secret`.
+    // client.setToken('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3VpdGVfand0In0.hPmHsVqvtY88PvK4EmJlcdwNuKFuy3BGaF7dMaKdPlw');
     await client.connect();
 
     final subscription = client.getSubscription(channel);
-    await subscription.subscribe();
 
     subscription.publishStream.map((e) => utf8.decode(e.data)).listen(onEvent);
     subscription.joinStream.listen(onEvent);
@@ -34,6 +35,8 @@ void main() async {
     subscription.subscribeSuccessStream.listen(onEvent);
     subscription.subscribeErrorStream.listen(onEvent);
     subscription.unsubscribeStream.listen(onEvent);
+
+    await subscription.subscribe();
 
     final handler = _handleUserInput(client, subscription);
 

--- a/example/console/simple.dart
+++ b/example/console/simple.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -16,8 +17,8 @@ void main() async {
       url,
       config: centrifuge.ClientConfig(
           headers: <String, dynamic>{'user-id': 42, 'user-name': 'The Answer'},
-          onPrivateSub: (centrifuge.PrivateSubEvent event) {
-            return '<SUBSCRIPTION JWT>';
+          onPrivateSub: (centrifuge.PrivateSubEvent event, Completer<String> completer) {
+            completer.complete('<SUBSCRIPTION JWT>');
           }),
     );
 

--- a/example/console/simple.dart
+++ b/example/console/simple.dart
@@ -17,8 +17,8 @@ void main() async {
       url,
       config: centrifuge.ClientConfig(
           headers: <String, dynamic>{'user-id': 42, 'user-name': 'The Answer'},
-          onPrivateSub: (centrifuge.PrivateSubEvent event, Completer<String> completer) {
-            completer.complete('<SUBSCRIPTION JWT>');
+          onPrivateSub: (centrifuge.PrivateSubEvent event) {
+            return Future.value('<SUBSCRIPTION JWT>');
           }),
     );
 

--- a/example/console/simple.dart
+++ b/example/console/simple.dart
@@ -52,28 +52,28 @@ void main() async {
 }
 
 Function(String) _handleUserInput(
-    centrifuge.Client centrifuge, centrifuge.Subscription subscription) {
+    centrifuge.Client client, centrifuge.Subscription subscription) {
   return (String message) async {
     switch (message) {
       case '#subscribe':
-        await subscription.subscribe();
+        subscription.subscribe();
         break;
       case '#unsubscribe':
-        await subscription.unsubscribe();
+        subscription.unsubscribe();
         break;
       case '#connect':
-        await centrifuge.connect();
+        client.connect();
         break;
       case '#disconnect':
-        await centrifuge.disconnect();
+        client.disconnect();
         break;
       default:
         final output = jsonEncode({'input': message});
         final data = utf8.encode(output);
         try {
           await subscription.publish(data);
-        } catch (ClientDisconnectedError) {
-          print("can't publish: client not connected");
+        } catch (ex) {
+          print("can't publish: $ex");
         }
         break;
     }

--- a/example/flutter_app/lib/main.dart
+++ b/example/flutter_app/lib/main.dart
@@ -60,15 +60,15 @@ class _MyHomePageState extends State<MyHomePage> {
           PopupMenuButton<Function>(
             onSelected: (f) => f(),
             itemBuilder: (context) => <PopupMenuItem<Function>>[
-                  PopupMenuItem(
-                    value: () => _connect(),
-                    child: Text('Connect'),
-                  ),
-                  PopupMenuItem(
-                    value: () => _subscribe(),
-                    child: Text('Subscribe'),
-                  ),
-                ],
+              PopupMenuItem(
+                value: () => _connect(),
+                child: Text('Connect'),
+              ),
+              PopupMenuItem(
+                value: () => _subscribe(),
+                child: Text('Subscribe'),
+              ),
+            ],
           )
         ],
       ),
@@ -142,10 +142,10 @@ class _MyHomePageState extends State<MyHomePage> {
     showDialog<AlertDialog>(
       context: context,
       builder: (_) => AlertDialog(
-            content: Text(
-              error.toString(),
-            ),
-          ),
+        content: Text(
+          error.toString(),
+        ),
+      ),
     );
   }
 }

--- a/example/flutter_app/lib/main.dart
+++ b/example/flutter_app/lib/main.dart
@@ -96,7 +96,6 @@ class _MyHomePageState extends State<MyHomePage> {
   void _subscribe() async {
     final channel = 'chat:index';
     _subscription = _centrifuge.getSubscription(channel);
-    await _subscription.subscribe();
 
     _subscription.subscribeErrorStream.listen(_show);
     _subscription.subscribeSuccessStream.listen(_show);
@@ -135,6 +134,8 @@ class _MyHomePageState extends State<MyHomePage> {
       final item = _ChatItem(title: message, subtitle: 'User: user');
       onNewItem(item);
     });
+
+    await _subscription.subscribe();
   }
 
   void _show(dynamic error) {

--- a/example/flutter_app/lib/main.dart
+++ b/example/flutter_app/lib/main.dart
@@ -87,7 +87,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   void _connect() async {
     try {
-      await _centrifuge.connect();
+      _centrifuge.connect();
     } catch (exception) {
       _show(exception);
     }
@@ -135,7 +135,7 @@ class _MyHomePageState extends State<MyHomePage> {
       onNewItem(item);
     });
 
-    await _subscription.subscribe();
+    _subscription.subscribe();
   }
 
   void _show(dynamic error) {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -283,12 +283,12 @@ class ClientImpl implements Client, GeneratedMessageSender {
   Future<String> getToken(String channel) async {
     if (_isPrivateChannel(channel)) {
       final event = PrivateSubEvent(_clientID, channel);
-      return onPrivateSub(event);
+      return _onPrivateSub(event);
     }
     return null;
   }
 
-  Future<String> onPrivateSub(PrivateSubEvent event) =>
+  Future<String> _onPrivateSub(PrivateSubEvent event) =>
       _config.onPrivateSub(event);
 
   bool _isPrivateChannel(String channel) =>

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -165,7 +165,7 @@ class ClientImpl implements Client, GeneratedMessageSender {
               Req request, Rep result) =>
           _transport.sendMessage(request, result);
 
-  int _retryCount;
+  int _retryCount = 0;
 
   void _processDisconnect({@required String reason, bool reconnect}) async {
     if (_state == _ClientState.disconnected) {
@@ -181,7 +181,6 @@ class ClientImpl implements Client, GeneratedMessageSender {
 
     if (reconnect) {
       _state = _ClientState.connecting;
-
       _retryCount += 1;
       await _config.retry(_retryCount);
       _connect();

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -25,7 +25,7 @@ abstract class Client {
 
   /// Connect to the server.
   ///
-  Future<void> connect();
+  void connect();
 
   /// Set token for connection request.
   ///
@@ -58,7 +58,7 @@ abstract class Client {
 
   /// Disconnect from the server.
   ///
-  Future<void> disconnect();
+  void disconnect();
 
   /// Get subscription to the channel.
   ///
@@ -67,7 +67,7 @@ abstract class Client {
   Subscription getSubscription(String channel);
 
   @alwaysThrows
-  Future<void> removeSubscription(Subscription subscription);
+  void removeSubscription(Subscription subscription);
 }
 
 class ClientImpl implements Client, GeneratedMessageSender {
@@ -86,8 +86,6 @@ class ClientImpl implements Client, GeneratedMessageSender {
   List<int> _connectData;
   String _clientID;
 
-  String get id => _clientID;
-
   final _connectController = StreamController<ConnectEvent>.broadcast();
   final _disconnectController = StreamController<DisconnectEvent>.broadcast();
   final _messageController = StreamController<MessageEvent>.broadcast();
@@ -104,7 +102,7 @@ class ClientImpl implements Client, GeneratedMessageSender {
   Stream<MessageEvent> get messageStream => _messageController.stream;
 
   @override
-  Future<void> connect() async {
+  void connect() async {
     return _connect();
   }
 
@@ -139,7 +137,7 @@ class ClientImpl implements Client, GeneratedMessageSender {
   }
 
   @override
-  Future<void> disconnect() async {
+  void disconnect() async {
     _processDisconnect(reason: 'manual disconnect', reconnect: false);
     await _transport.close();
   }
@@ -284,7 +282,7 @@ class ClientImpl implements Client, GeneratedMessageSender {
 
   String getToken(String channel) {
     if (_isPrivateChannel(channel)) {
-      final event = PrivateSubEvent(id, channel);
+      final event = PrivateSubEvent(_clientID, channel);
       return onPrivateSub(event);
     }
     return null;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -280,19 +280,17 @@ class ClientImpl implements Client, GeneratedMessageSender {
     }
   }
 
-  Future<String> getToken(String channel) {
-    final completer = new Completer<String>();
+  Future<String> getToken(String channel) async {
     if (_isPrivateChannel(channel)) {
       final event = PrivateSubEvent(_clientID, channel);
-      onPrivateSub(event, completer);
-      return completer.future;
+      return await onPrivateSub(event);
     }
-    completer.complete(null);
-    return completer.future;
+    return Future.value(null);
   }
 
-  String onPrivateSub(PrivateSubEvent event, Completer<String> completer) => 
-      _config.onPrivateSub(event, completer);
+  Future<String> onPrivateSub(PrivateSubEvent event) {
+      return _config.onPrivateSub(event);
+  }
 
   bool _isPrivateChannel(String channel) =>
       channel.startsWith(_config.privateChannelPrefix);

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -283,14 +283,13 @@ class ClientImpl implements Client, GeneratedMessageSender {
   Future<String> getToken(String channel) async {
     if (_isPrivateChannel(channel)) {
       final event = PrivateSubEvent(_clientID, channel);
-      return await onPrivateSub(event);
+      return onPrivateSub(event);
     }
-    return Future.value(null);
+    return null;
   }
 
-  Future<String> onPrivateSub(PrivateSubEvent event) {
-      return _config.onPrivateSub(event);
-  }
+  Future<String> onPrivateSub(PrivateSubEvent event) =>
+      _config.onPrivateSub(event);
 
   bool _isPrivateChannel(String channel) =>
       channel.startsWith(_config.privateChannelPrefix);

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -280,15 +280,19 @@ class ClientImpl implements Client, GeneratedMessageSender {
     }
   }
 
-  String getToken(String channel) {
+  Future<String> getToken(String channel) {
+    final completer = new Completer<String>();
     if (_isPrivateChannel(channel)) {
       final event = PrivateSubEvent(_clientID, channel);
-      return onPrivateSub(event);
+      onPrivateSub(event, completer);
+      return completer.future;
     }
-    return null;
+    completer.complete(null);
+    return completer.future;
   }
 
-  String onPrivateSub(PrivateSubEvent event) => _config.onPrivateSub(event);
+  String onPrivateSub(PrivateSubEvent event, Completer<String> completer) => 
+      _config.onPrivateSub(event, completer);
 
   bool _isPrivateChannel(String channel) =>
       channel.startsWith(_config.privateChannelPrefix);

--- a/lib/src/client_config.dart
+++ b/lib/src/client_config.dart
@@ -40,5 +40,5 @@ WaitRetry _defaultRetry(int maxReconnectDelay) => (int count) {
     };
 
 String _defaultPrivateSubCallback(PrivateSubEvent event) {
-    throw UnimplementedError();
-    }
+  throw UnimplementedError();
+}

--- a/lib/src/client_config.dart
+++ b/lib/src/client_config.dart
@@ -39,4 +39,5 @@ WaitRetry _defaultRetry(int maxReconnectDelay) => (int count) {
       return Future<void>.delayed(Duration(seconds: seconds));
     };
 
-Future<String> _defaultPrivateSubCallback(PrivateSubEvent event) => Future.value("");
+Future<String> _defaultPrivateSubCallback(PrivateSubEvent event) =>
+    Future.value("");

--- a/lib/src/client_config.dart
+++ b/lib/src/client_config.dart
@@ -32,13 +32,13 @@ class ClientConfig {
 
 typedef WaitRetry = Future Function(int);
 
-typedef PrivateSubCallback = String Function(PrivateSubEvent);
+typedef PrivateSubCallback = Function(PrivateSubEvent, Completer<String>);
 
 WaitRetry _defaultRetry(int maxReconnectDelay) => (int count) {
       final seconds = min(0.5 * pow(2, count), maxReconnectDelay).toInt();
       return Future<void>.delayed(Duration(seconds: seconds));
     };
 
-String _defaultPrivateSubCallback(PrivateSubEvent event) {
-  throw UnimplementedError();
+void _defaultPrivateSubCallback(PrivateSubEvent event, Completer<String> completer) {
+  completer.complete("");
 }

--- a/lib/src/client_config.dart
+++ b/lib/src/client_config.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:centrifuge/centrifuge.dart';
+import 'package:centrifuge/src/events.dart';
+
 class ClientConfig {
   ClientConfig(
       {this.timeout = const Duration(seconds: 5),
@@ -10,6 +13,7 @@ class ClientConfig {
       this.maxReconnectDelay = const Duration(seconds: 20),
       this.privateChannelPrefix = "\$",
       this.pingInterval = const Duration(seconds: 25),
+      this.onPrivateSub = _defaultPrivateSubCallback,
       WaitRetry retry})
       : retry = retry ?? _defaultRetry(maxReconnectDelay.inSeconds);
 
@@ -22,12 +26,19 @@ class ClientConfig {
   final Duration maxReconnectDelay;
   final String privateChannelPrefix;
   final Duration pingInterval;
+  final PrivateSubCallback onPrivateSub;
   final Future Function(int) retry;
 }
 
 typedef WaitRetry = Future Function(int);
 
+typedef PrivateSubCallback = String Function(PrivateSubEvent);
+
 WaitRetry _defaultRetry(int maxReconnectDelay) => (int count) {
       final seconds = min(0.5 * pow(2, count), maxReconnectDelay).toInt();
       return Future<void>.delayed(Duration(seconds: seconds));
     };
+
+String _defaultPrivateSubCallback(PrivateSubEvent event) {
+    throw UnimplementedError();
+    }

--- a/lib/src/client_config.dart
+++ b/lib/src/client_config.dart
@@ -32,13 +32,13 @@ class ClientConfig {
 
 typedef WaitRetry = Future Function(int);
 
-typedef PrivateSubCallback = Function(PrivateSubEvent, Completer<String>);
+typedef PrivateSubCallback = Future<String> Function(PrivateSubEvent);
 
 WaitRetry _defaultRetry(int maxReconnectDelay) => (int count) {
       final seconds = min(0.5 * pow(2, count), maxReconnectDelay).toInt();
       return Future<void>.delayed(Duration(seconds: seconds));
     };
 
-void _defaultPrivateSubCallback(PrivateSubEvent event, Completer<String> completer) {
-  completer.complete("");
+Future<String> _defaultPrivateSubCallback(PrivateSubEvent event) {
+    return Future.value("");
 }

--- a/lib/src/client_config.dart
+++ b/lib/src/client_config.dart
@@ -39,6 +39,4 @@ WaitRetry _defaultRetry(int maxReconnectDelay) => (int count) {
       return Future<void>.delayed(Duration(seconds: seconds));
     };
 
-Future<String> _defaultPrivateSubCallback(PrivateSubEvent event) {
-    return Future.value("");
-}
+Future<String> _defaultPrivateSubCallback(PrivateSubEvent event) => Future.value("");

--- a/lib/src/error.dart
+++ b/lib/src/error.dart
@@ -12,7 +12,6 @@ class Error {
 }
 
 class ClientDisconnectedError {
-
   @override
   String toString() {
     return 'Client disconnected';

--- a/lib/src/error.dart
+++ b/lib/src/error.dart
@@ -10,3 +10,11 @@ class Error {
     return 'Error{code: $code, message: $message}';
   }
 }
+
+class ClientDisconnectedError {
+
+  @override
+  String toString() {
+    return 'Client disconnected';
+  }
+}

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -58,8 +58,7 @@ class PublishEvent {
 
   final List<int> data;
 
-  static PublishEvent from(proto.Publication pub) =>
-      PublishEvent(pub.data);
+  static PublishEvent from(proto.Publication pub) => PublishEvent(pub.data);
 
   @override
   String toString() {
@@ -72,8 +71,7 @@ class HistoryEvent {
 
   final List<int> data;
 
-  static HistoryEvent from(proto.Publication pub) =>
-      HistoryEvent(pub.data);
+  static HistoryEvent from(proto.Publication pub) => HistoryEvent(pub.data);
 
   @override
   String toString() {

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -135,8 +135,8 @@ class SubscribeErrorEvent {
   final String message;
   final int code;
 
-  static SubscribeErrorEvent from(proto.Error error) =>
-      SubscribeErrorEvent(error.message, error.code);
+  static SubscribeErrorEvent from(int code, String message) =>
+      SubscribeErrorEvent(message, code);
 
   @override
   String toString() {

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -54,32 +54,30 @@ class MessageEvent {
 }
 
 class PublishEvent {
-  PublishEvent(this.uid, this.data);
+  PublishEvent(this.data);
 
-  final String uid;
   final List<int> data;
 
   static PublishEvent from(proto.Publication pub) =>
-      PublishEvent(pub.uid, pub.data);
+      PublishEvent(pub.data);
 
   @override
   String toString() {
-    return 'PublishEvent{uid: $uid, data: $data}';
+    return 'PublishEvent{data: $data}';
   }
 }
 
 class HistoryEvent {
-  HistoryEvent(this.uid, this.data);
+  HistoryEvent(this.data);
 
-  final String uid;
   final List<int> data;
 
   static HistoryEvent from(proto.Publication pub) =>
-      HistoryEvent(pub.uid, pub.data);
+      HistoryEvent(pub.data);
 
   @override
   String toString() {
-    return 'HistoryEvent{uid: $uid, data: $data}';
+    return 'HistoryEvent{data: $data}';
   }
 }
 

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -135,9 +135,6 @@ class SubscribeErrorEvent {
   final String message;
   final int code;
 
-  static SubscribeErrorEvent from(int code, String message) =>
-      SubscribeErrorEvent(message, code);
-
   @override
   String toString() {
     return 'SubscribeErrorEvent{message: $message, code: $code}';

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -76,8 +76,8 @@ class SubscriptionImpl implements Subscription {
   @override
   Future subscribe() {
     _state = _SubscriptionState.subscribed;
-    if (!_client.connected()) {
-        return Future<void>.value(null);
+    if (!_client.connected) {
+      return Future<void>.value(null);
     }
     return _resubscribe(isResubscribed: false);
   }
@@ -136,11 +136,9 @@ class SubscriptionImpl implements Subscription {
   Future _resubscribe({@required bool isResubscribed}) async {
     try {
       final request = SubscribeRequest()
-        ..channel = channel;
-      if (channel.startsWith(_client.config.privateChannelPrefix)) {
-        final token = _client.config.onPrivateSub(PrivateSubEvent(_client.id, channel));
-        request..token = token;
-      }
+        ..channel = channel
+        ..token = _client.getToken(channel) ?? '';
+
       final result = await _client.sendMessage(request, SubscribeResult());
       final event = SubscribeSuccessEvent.from(result, isResubscribed);
       _onSubscribeSuccess(event);

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -139,9 +139,11 @@ class SubscriptionImpl implements Subscription {
 
   Future _resubscribe({@required bool isResubscribed}) async {
     try {
+      final token = await _client.getToken(channel);
+
       final request = SubscribeRequest()
         ..channel = channel
-        ..token = _client.getToken(channel) ?? '';
+        ..token = token ?? '';
 
       final result = await _client.sendMessage(request, SubscribeResult());
       final event = SubscribeSuccessEvent.from(result, isResubscribed);

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -140,7 +140,6 @@ class SubscriptionImpl implements Subscription {
   Future _resubscribe({@required bool isResubscribed}) async {
     try {
       final token = await _client.getToken(channel);
-
       final request = SubscribeRequest()
         ..channel = channel
         ..token = token ?? '';

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import 'client.dart';
+import 'error.dart' as errors;
 import 'events.dart';
 import 'proto/client.pb.dart';
 
@@ -138,8 +139,8 @@ class SubscriptionImpl implements Subscription {
       _onSubscribeSuccess(event);
       _recover(result);
     } catch (exception) {
-      if (exception is Error) {
-        _onSubscribeError(SubscribeErrorEvent.from(exception));
+      if (exception is errors.Error) {
+        _onSubscribeError(SubscribeErrorEvent.from(exception.code, exception.message));
       } else {
         _onSubscribeError(SubscribeErrorEvent(exception.toString(), -1));
       }

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -22,9 +22,9 @@ abstract class Subscription {
 
   Stream<UnsubscribeEvent> get unsubscribeStream;
 
-  Future subscribe();
+  void subscribe();
 
-  Future unsubscribe();
+  void unsubscribe();
 
   Future publish(List<int> data);
 
@@ -74,12 +74,12 @@ class SubscriptionImpl implements Subscription {
   Future publish(List<int> data) => _client.publish(channel, data);
 
   @override
-  Future subscribe() {
+  void subscribe() async {
     _state = _SubscriptionState.subscribed;
     if (!_client.connected) {
-      return Future<void>.value(null);
+      return;
     }
-    return _resubscribe(isResubscribed: false);
+    await _resubscribe(isResubscribed: false);
   }
 
   Future resubscribeIfNeeded() {
@@ -90,11 +90,15 @@ class SubscriptionImpl implements Subscription {
   }
 
   @override
-  Future unsubscribe() async {
+  void unsubscribe() async {
     if (_state != _SubscriptionState.subscribed) {
-      return Future<void>.value(null);
+      return;
     }
     _state = _SubscriptionState.unsubscribed;
+
+    if (!_client.connected) {
+      return;
+    }
 
     final request = UnsubscribeRequest()..channel = channel;
     await _client.sendMessage(request, UnsubscribeResult());

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -74,19 +74,19 @@ class SubscriptionImpl implements Subscription {
   Future publish(List<int> data) => _client.publish(channel, data);
 
   @override
-  void subscribe() async {
+  void subscribe() {
     _state = _SubscriptionState.subscribed;
     if (!_client.connected) {
       return;
     }
-    await _resubscribe(isResubscribed: false);
+    _resubscribe(isResubscribed: false);
   }
 
-  Future resubscribeIfNeeded() {
+  void resubscribeIfNeeded() {
     if (_state != _SubscriptionState.subscribed) {
-      return Future<void>.value(null);
+      return null;
     }
-    return _resubscribe(isResubscribed: true);
+    _resubscribe(isResubscribed: true);
   }
 
   @override

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -140,7 +140,8 @@ class SubscriptionImpl implements Subscription {
       _recover(result);
     } catch (exception) {
       if (exception is errors.Error) {
-        _onSubscribeError(SubscribeErrorEvent.from(exception.code, exception.message));
+        _onSubscribeError(
+            SubscribeErrorEvent.from(exception.code, exception.message));
       } else {
         _onSubscribeError(SubscribeErrorEvent(exception.toString(), -1));
       }

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -141,7 +141,7 @@ class SubscriptionImpl implements Subscription {
     } catch (exception) {
       if (exception is errors.Error) {
         _onSubscribeError(
-            SubscribeErrorEvent.from(exception.code, exception.message));
+            SubscribeErrorEvent(exception.message, exception.code));
       } else {
         _onSubscribeError(SubscribeErrorEvent(exception.toString(), -1));
       }

--- a/lib/src/transport.dart
+++ b/lib/src/transport.dart
@@ -50,7 +50,8 @@ abstract class GeneratedMessageSender {
 }
 
 class Transport implements GeneratedMessageSender {
-  Transport(this._socketBuilder, this._config, this._commandEncoder, this._replyDecoder);
+  Transport(this._socketBuilder, this._config, this._commandEncoder,
+      this._replyDecoder);
 
   final WebSocketBuilder _socketBuilder;
   WebSocket _socket;
@@ -104,9 +105,11 @@ class Transport implements GeneratedMessageSender {
     _completers[command.id] = completer;
 
     final data = _commandEncoder.convert(command);
+
     if (_socket == null) {
       throw centrifuge.ClientDisconnectedError;
     }
+
     _socket.add(data);
 
     return completer.future;

--- a/lib/src/transport.dart
+++ b/lib/src/transport.dart
@@ -23,9 +23,9 @@ Transport protobufTransportBuilder(
 
   final transport = Transport(
     () => WebSocket.connect(
-          url,
-          headers: headers,
-        ),
+      url,
+      headers: headers,
+    ),
     commandEncoder,
     replyDecoder,
   );

--- a/lib/src/transport.dart
+++ b/lib/src/transport.dart
@@ -83,7 +83,6 @@ class Transport implements GeneratedMessageSender {
       sendMessage<Req extends GeneratedMessage, Rep extends GeneratedMessage>(
           Req request, Rep result) async {
     final command = _createCommand(request);
-
     final reply = await _sendCommand(command);
 
     final filledResult = _processResult(result, reply);

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -13,20 +13,22 @@ void main() {
 
   Client client;
   MockTransport transport;
-  ClientConfig config;
+  ClientConfig clientConfig;
   WaitRetry retry;
+
   final subscription = (String name) => client.getSubscription(name);
 
   setUp(() {
     transport = MockTransport();
-    config = ClientConfig(retry: (count) => retry?.call(count));
+    clientConfig = ClientConfig(retry: (count) => retry?.call(count));
 
     client = ClientImpl(
-        url,
-        config,
-        ({url, headers}) => transport
-          ..url = url
-          ..headers = headers);
+      url,
+      clientConfig,
+      ({url, config}) => transport
+        ..url = url
+        ..transportConfig = config,
+    );
   });
 
   group('Subscription', () {
@@ -50,7 +52,7 @@ void main() {
       transport.completeOpen();
 
       expect(transport.url, equals(url));
-      expect(transport.headers, same(config.headers));
+      expect(transport.transportConfig.headers, same(clientConfig.headers));
     });
     test('connect sends request with data and token', () async {
       client.setToken('test token');

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -343,7 +343,7 @@ void main() {
       expect(countClientConnect, 20);
       expect(countClientDisconnect, 20);
 
-      expect(countOneChannelSubscribe, 21);
+      expect(countOneChannelSubscribe, 20);
       expect(countOneChannelUnsubscribe, 20);
 
       expect(countTwoChannelSubscribe, 0);

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -72,7 +72,8 @@ void main() {
     test('connect sends request and emits connect event', () async {
       final eventFuture = client.connectStream.first;
 
-      final connectFinish = client.connect();
+      final connectFinish = client.connectStream.first;
+      client.connect();
       transport.completeOpen();
 
       final send = transport.sendListLast<ConnectRequest, ConnectResult>();

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:centrifuge/centrifuge.dart';
 import 'package:centrifuge/src/client.dart';
 import 'package:centrifuge/src/proto/client.pb.dart' hide Error;
 import 'package:centrifuge/src/transport.dart';
@@ -11,6 +12,9 @@ class MockWebSocket implements WebSocket {
   final List<Command> commands = <Command>[];
 
   final _stubs = <CommandMatcher, SendAction>{};
+
+  @override
+  Duration pingInterval;
 
   @override
   String closeReason;
@@ -92,7 +96,7 @@ CommandMatcher withMethod(MethodType type) =>
 
 class MockTransport implements Transport {
   String url;
-  Map<String, dynamic> headers;
+  TransportConfig transportConfig;
 
   @override
   Future close() {
@@ -182,4 +186,10 @@ class Triplet<Req extends GeneratedMessage, Res extends GeneratedMessage> {
   int get hashCode => request.hashCode ^ completer.hashCode ^ result.hashCode;
 }
 
-class MockClient extends Mock with MockTransport implements ClientImpl {}
+class MockClient extends Mock with MockTransport implements ClientImpl {
+  @override
+  ClientConfig config;
+
+  @override
+  bool connected;
+}

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -186,7 +186,7 @@ class Triplet<Req extends GeneratedMessage, Res extends GeneratedMessage> {
   int get hashCode => request.hashCode ^ completer.hashCode ^ result.hashCode;
 }
 
-class MockClient extends Mock with MockTransport implements ClientImpl {
+class MockClient extends Mock implements ClientImpl {
   @override
   ClientConfig config;
 

--- a/test/subscription_test.dart
+++ b/test/subscription_test.dart
@@ -12,6 +12,7 @@ void main() {
 
   setUp(() {
     client = MockClient();
+    client.connected = true;
     subscription = SubscriptionImpl('test channel', client);
   });
 

--- a/test/transport_test.dart
+++ b/test/transport_test.dart
@@ -25,6 +25,7 @@ void main() {
 
     transport = Transport(
       () => Future.value(webSocket),
+      TransportConfig(),
       ProtobufCommandEncoder(),
       ProtobufReplyDecoder(),
     );


### PR DESCRIPTION
This pull request contains a bunch of client improvements and fixes:
1) Use Websocket Ping/Pong frames to find broken connections
2) Add proper support for private channel subscription - with callback on every attempt to subscribe to private chanel
3) Fix null pointer dereference when sending requests while client disconnected - throw `ClientDisconnectedError` in this case