### PR TITLE
Upgrade Android compileSdkVersion to 28 in example

### DIFF
--- a/example/flutter_app/android/app/build.gradle
+++ b/example/flutter_app/android/app/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -25,7 +25,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.centrifugeapp"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/example/flutter_app/android/gradle.properties
+++ b/example/flutter_app/android/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true


### PR DESCRIPTION
The example throws an appcompat exception:

> Execution failed for task ':app:processDebugResources'.
> Android resource linking failed

I increased the `compileSdkVersion` and `targetSdkVersion` to 28 in the app level `build.graddle` file for Android to avoid this error. This makes the example to compile without errors on the latest Flutter: 28 is the standard now