### PR TITLE
Subprotocol to avoid URL param

### DIFF
--- a/example/console_server_subs/example.dart
+++ b/example/console_server_subs/example.dart
@@ -25,7 +25,7 @@ void main() async {
     client.leaveStream.listen(onEvent);
 
     // Uncomment to use example token based on secret key `secret`.
-    client.setToken('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3VpdGVfand0In0.hPmHsVqvtY88PvK4EmJlcdwNuKFuy3BGaF7dMaKdPlw');
+    // client.setToken('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3VpdGVfand0In0.hPmHsVqvtY88PvK4EmJlcdwNuKFuy3BGaF7dMaKdPlw');
     client.connect();
 
     final handler = _handleUserInput(client);

--- a/lib/src/transport.dart
+++ b/lib/src/transport.dart
@@ -32,6 +32,7 @@ Transport protobufTransportBuilder(
   final transport = Transport(
     () => WebSocket.connect(
       url,
+      protocols: ["centrifuge-protobuf"],
       headers: config.headers,
     ),
     config,


### PR DESCRIPTION
This will allow omit `?format=protobuf` when working with Centrifugo v3 and Centrifuge >= v0.18.0