### PR TITLE
Avoid using late var, avoid sending malformed token in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.9.1]
+
+* Fix setting initial connection token
+* Fix LateInitializationError if transport is not initialized yet 
+
 ## [0.9.0]
 
 **Breaking changes**

--- a/example/console/example.dart
+++ b/example/console/example.dart
@@ -16,11 +16,12 @@ void main() async {
     final client = centrifuge.createClient(
       url,
       centrifuge.ClientConfig(
-        // Uncomment to use example token based on secret key `secret`.
-        // token:
-        // 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3VpdGVfand0In0.hPmHsVqvtY88PvK4EmJlcdwNuKFuy3BGaF7dMaKdPlw',
+        // Uncomment to use example token based on secret key `secret` for user `testsuite_jwt`.
+        token:
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3VpdGVfand0In0.hPmHsVqvtY88PvK4EmJlcdwNuKFuy3BGaF7dMaKdPlw',
         // getToken: (centrifuge.ConnectionTokenEvent event) {
-        //   return Future.value('');
+        //   return Future.value(
+        //       'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3VpdGVfand0In0.hPmHsVqvtY88PvK4EmJlcdwNuKFuy3BGaF7dMaKdPlw');
         // },
         headers: <String, dynamic>{'X-Example-Header': 'example'},
       ),
@@ -45,10 +46,10 @@ void main() async {
     final subscription = client.newSubscription(
       channel,
       centrifuge.SubscriptionConfig(
-          // getToken: (centrifuge.SubscriptionTokenEvent event) {
-          //   return Future.value('');
-          // },
-          ),
+        getToken: (centrifuge.SubscriptionTokenEvent event) {
+          return Future.value('');
+        },
+      ),
     );
 
     final onSubscriptionEvent = (dynamic event) async {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -98,9 +98,7 @@ abstract class Client {
 }
 
 class ClientImpl implements Client {
-  ClientImpl(this._url, this._config, this._transportBuilder) {
-    _token = _config.token;
-  }
+  ClientImpl(this._url, this._config, this._transportBuilder);
 
   final TransportBuilder _transportBuilder;
   final _subscriptions = <String, SubscriptionImpl>{};

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -98,13 +98,15 @@ abstract class Client {
 }
 
 class ClientImpl implements Client {
-  ClientImpl(this._url, this._config, this._transportBuilder);
+  ClientImpl(this._url, this._config, this._transportBuilder) {
+    _token = _config.token;
+  }
 
   final TransportBuilder _transportBuilder;
   final _subscriptions = <String, SubscriptionImpl>{};
   final _serverSubs = <String, ServerSubscription>{};
 
-  late Transport _transport;
+  Transport? _transport;
 
   final String _url;
   ClientConfig _config;
@@ -192,7 +194,7 @@ class ClientImpl implements Client {
   Future<void> disconnect() async {
     _reconnectAttempts = 0;
     _processDisconnect(code: disconnectedCodeDisconnectCalled, reason: 'disconnect called', reconnect: false);
-    await _transport.close();
+    await _transport?.close();
   }
 
   @override
@@ -214,7 +216,7 @@ class ClientImpl implements Client {
     final request = protocol.PublishRequest()
       ..channel = channel
       ..data = data;
-    final result = await _transport.sendMessage(
+    final result = await _transport!.sendMessage(
       request,
       protocol.PublishResult(),
     );
@@ -227,7 +229,7 @@ class ClientImpl implements Client {
     final request = protocol.RPCRequest();
     request.method = method;
     request.data = data;
-    final result = await _transport.sendMessage(request, protocol.RPCResult());
+    final result = await _transport!.sendMessage(request, protocol.RPCResult());
     return RPCResult.from(result);
   }
 
@@ -244,7 +246,7 @@ class ClientImpl implements Client {
       sp.epoch = since.epoch;
       request.since = sp;
     }
-    final result = await _transport.sendMessage(
+    final result = await _transport!.sendMessage(
       request,
       protocol.HistoryResult(),
     );
@@ -255,7 +257,7 @@ class ClientImpl implements Client {
   Future<PresenceResult> presence(String channel) async {
     await ready().timeout(_config.timeout);
     final request = protocol.PresenceRequest()..channel = channel;
-    final result = await _transport.sendMessage(
+    final result = await _transport!.sendMessage(
       request,
       protocol.PresenceResult(),
     );
@@ -266,7 +268,7 @@ class ClientImpl implements Client {
   Future<PresenceStatsResult> presenceStats(String channel) async {
     await ready().timeout(_config.timeout);
     final request = protocol.PresenceStatsRequest()..channel = channel;
-    final result = await _transport.sendMessage(
+    final result = await _transport!.sendMessage(
       request,
       protocol.PresenceStatsResult(),
     );
@@ -277,7 +279,7 @@ class ClientImpl implements Client {
   Future<void> send(List<int> data) async {
     await ready().timeout(_config.timeout);
     final request = protocol.Message()..data = data;
-    await _transport.sendAsyncMessage(request);
+    await _transport!.sendAsyncMessage(request);
   }
 
   @override
@@ -357,7 +359,10 @@ class ClientImpl implements Client {
 
   void _failUnauthorized() {
     _processDisconnect(code: disconnectedCodeUnauthorized, reason: 'unauthorized', reconnect: false);
-    _transport.close();
+    if (_transport == null) {
+      return;
+    }
+    _transport!.close();
   }
 
   void _scheduleReconnect() {
@@ -389,7 +394,9 @@ class ClientImpl implements Client {
       } catch (ex) {
         final event = ErrorEvent(RefreshError(ex));
         _errorController.add(event);
-        await _transport.close();
+        if (_transport != null) {
+          await _transport!.close();
+        }
         _scheduleReconnect();
         return;
       }
@@ -399,14 +406,14 @@ class ClientImpl implements Client {
         url: _url, config: TransportConfig(headers: _config.headers, timeout: _config.timeout));
 
     try {
-      await _transport.open(_onPush, onError: (dynamic error) {
+      await _transport!.open(_onPush, onError: (dynamic error) {
         final event = ErrorEvent(TransportError(error));
         _errorController.add(event);
         if (state != State.connected) {
           return;
         }
         _processDisconnect(code: connectingCodeTransportClosed, reason: "connection closed", reconnect: true);
-        _transport.close();
+        _transport!.close();
       }, onDone: (code, reason, reconnect) {
         if (state == State.disconnected) {
           return;
@@ -416,7 +423,7 @@ class ClientImpl implements Client {
     } catch (ex) {
       final event = ErrorEvent(TransportError(ex));
       _errorController.add(event);
-      await _transport.close();
+      await _transport!.close();
       _scheduleReconnect();
       return;
     }
@@ -442,7 +449,7 @@ class ClientImpl implements Client {
     }
 
     try {
-      final result = await _transport.sendMessage(
+      final result = await _transport!.sendMessage(
         request,
         protocol.ConnectResult(),
       );
@@ -504,11 +511,11 @@ class ClientImpl implements Client {
           return;
         } else if (!err.temporary) {
           _processDisconnect(code: err.code, reason: err.message, reconnect: false);
-          _transport.close();
+          _transport!.close();
           return;
         } else {
           _processDisconnect(code: err.code, reason: err.message, reconnect: false);
-          _transport.close();
+          _transport!.close();
           return;
         }
       } else {
@@ -524,7 +531,7 @@ class ClientImpl implements Client {
         return;
       }
       processDisconnect(code: connectingCodeNoPing, reason: 'no ping', reconnect: true);
-      await _transport.close();
+      await _transport!.close();
     });
   }
 
@@ -562,7 +569,7 @@ class ClientImpl implements Client {
     }
 
     try {
-      final result = await _transport.sendMessage(
+      final result = await _transport!.sendMessage(
         request,
         protocol.RefreshResult(),
       );
@@ -592,7 +599,7 @@ class ClientImpl implements Client {
           return;
         }
         _processDisconnect(code: err.code, reason: err.message, reconnect: false);
-        _transport.close();
+        _transport!.close();
         return;
       }
       _refreshTimer = Timer(backoffDelay(0, Duration(seconds: 5), Duration(seconds: 10)), () {
@@ -670,7 +677,7 @@ class ClientImpl implements Client {
     final code = disconnect.code;
     final bool reconnect = code < 3500 || code >= 5000 || (code >= 4000 && code < 4500);
     _processDisconnect(code: disconnect.code, reason: disconnect.reason, reconnect: reconnect);
-    _transport.close();
+    _transport!.close();
   }
 
   void _handleSubscribe(String channel, protocol.Subscribe subscribe) {
@@ -703,7 +710,7 @@ class ClientImpl implements Client {
     _setPingTimer();
 
     if (_sendPong) {
-      _transport.sendAsyncMessage(
+      _transport!.sendAsyncMessage(
         protocol.Command(),
       );
     }
@@ -733,7 +740,7 @@ class ClientImpl implements Client {
 
   @internal
   Future<protocol.UnsubscribeResult> sendUnsubscribe(protocol.UnsubscribeRequest request) async {
-    return await _transport.sendMessage(
+    return await _transport!.sendMessage(
       request,
       protocol.UnsubscribeResult(),
     );
@@ -741,7 +748,7 @@ class ClientImpl implements Client {
 
   @internal
   Future<protocol.SubscribeResult> sendSubscribe(protocol.SubscribeRequest request) async {
-    return await _transport.sendMessage(
+    return await _transport!.sendMessage(
       request,
       protocol.SubscribeResult(),
     );
@@ -749,7 +756,7 @@ class ClientImpl implements Client {
 
   @internal
   Future<protocol.SubRefreshResult> sendSubRefresh(protocol.SubRefreshRequest request) async {
-    return await _transport.sendMessage(
+    return await _transport!.sendMessage(
       request,
       protocol.SubRefreshResult(),
     );
@@ -761,7 +768,7 @@ class ClientImpl implements Client {
   }
 
   @internal
-  void closeTransport() async => await _transport.close();
+  void closeTransport() async => await _transport!.close();
 }
 
 final _random = new Random();

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -373,7 +373,7 @@ class UnsubscribedEvent {
 
   @override
   String toString() {
-    return 'UnsubscribedEvent{}';
+    return 'UnsubscribedEvent{code $code, reason: $reason}';
   }
 }
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -20,7 +20,7 @@ void main() {
     test('connect emits error event when url invalid', () async {
       final client = centrifuge.createClient(
         "invalid",
-        centrifuge.ClientConfig(token: "test", data: utf8.encode('test connect data')),
+        centrifuge.ClientConfig(data: utf8.encode('test connect data')),
       );
       final errorFinish = client.error.first;
       client.connect();
@@ -31,7 +31,7 @@ void main() {
     test('can connect and disconnect', () async {
       final client = centrifuge.createClient(
         url,
-        centrifuge.ClientConfig(token: "test", data: utf8.encode('test connect data')),
+        centrifuge.ClientConfig(data: utf8.encode('test connect data')),
       );
       final connectFinish = client.connected.first;
       client.connect();


### PR DESCRIPTION
* Avoid late _transport var usage, fixes `LateInitializationError` if connection token is empty 
* Better string representation of `UnsubscribedEvent`
* Avoid sending malformed token in test