### PR TITLE
Close subscription streams on remove

### DIFF
--- a/example/console/example.dart
+++ b/example/console/example.dart
@@ -93,6 +93,9 @@ Function(String) _handleUserInput(centrifuge.Client client, centrifuge.Subscript
       case '#unsubscribe':
         await subscription.unsubscribe();
         break;
+      case '#remove':
+        await client.removeSubscription(subscription);
+        break;
       case '#connect':
         await client.connect();
         break;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -91,7 +91,7 @@ abstract class Client {
 
   /// Remove the [Subscription] from internal registry and unsubscribe from [Subscription.channel].
   ///
-  void removeSubscription(Subscription subscription);
+  Future<void> removeSubscription(Subscription subscription);
 
   /// Get map wirth all registered client-side subscriptions.
   Map<String, Subscription> subscriptions();
@@ -302,9 +302,10 @@ class ClientImpl implements Client {
   }
 
   @override
-  void removeSubscription(Subscription subscription) {
+  Future<void> removeSubscription(Subscription subscription) async {
     final String channel = subscription.channel;
-    subscription.unsubscribe();
+    await subscription.unsubscribe();
+    _subscriptions[channel]?.close();
     _subscriptions.remove(channel);
   }
 

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -124,6 +124,17 @@ class SubscriptionImpl implements Subscription {
   }
 
   @internal
+  void close() {
+    _publicationController.close();
+    _joinController.close();
+    _leaveController.close();
+    _unsubscribedController.close();
+    _errorController.close();
+    _subscribedController.close();
+    _subscribingController.close();
+  }
+
+  @internal
   Future<void> moveToUnsubscribed(int code, String reason, bool sendUnsubscribe) async {
     if (state == SubscriptionState.unsubscribed) {
       return;

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -47,12 +47,12 @@ void main() {
   });
 
   group('Subscription', () {
-    test('newSubscription/removeSubscription work correctly', () {
+    test('newSubscription/removeSubscription work correctly', () async {
       final client = centrifuge.createClient(url, centrifuge.ClientConfig());
       final s1 = client.newSubscription('some_channel');
       expect(true, client.getSubscription(s1.channel) != null);
       expect(true, client.subscriptions().isNotEmpty);
-      client.removeSubscription(s1);
+      await client.removeSubscription(s1);
       expect(false, client.getSubscription(s1.channel) != null);
     });
 


### PR DESCRIPTION
This allows exiting from async stream iterators when subscription is removed from Client's registry (i.e. when `Client.removeSubscription` is called):

```dart
final subscription = client.newSubscription(...);

final onPublicationEvent = () async {
  await for (var i in subscription.publication) {
    print('publication: $i');
  }
  print("subscription removed");
};
onPublicationEvent();
client.removeSubscription(subscription)
```

Adresses #65 