### PR TITLE
Reconnect improvements, avoid ClientDisconnectedError in _onPing

### DIFF
--- a/example/console/example.dart
+++ b/example/console/example.dart
@@ -22,14 +22,13 @@ void main() async {
 
   try {
     final client = centrifuge.createClient(
-      url,
-      centrifuge.ClientConfig(
+        url,
+        centrifuge.ClientConfig(
           name: userName,
           token: userJwtToken,
           // Headers are only supported on platforms that support dart:io
           headers: <String, dynamic>{'X-Example-Header': 'example'},
-          minReconnectDelay: Duration(milliseconds: 50)),
-    );
+        ));
 
     // State changes.
     client.connecting.listen(onEvent);
@@ -50,11 +49,11 @@ void main() async {
     final subscription = client.newSubscription(
       channel,
       centrifuge.SubscriptionConfig(
-          // token: subscriptionJwtToken,
-          // getToken: (centrifuge.SubscriptionTokenEvent event) {
-          //   return Future.value('');
-          // },
-          ),
+        token: subscriptionJwtToken,
+        // getToken: (centrifuge.SubscriptionTokenEvent event) {
+        //   return Future.value('');
+        // },
+      ),
     );
 
     final onSubscriptionEvent = (dynamic event) async {
@@ -90,7 +89,6 @@ void main() async {
 }
 
 Function(String) _handleUserInput(centrifuge.Client client, centrifuge.Subscription subscription) {
-  var c = 0;
   return (String message) async {
     switch (message) {
       case '#subscribe':

--- a/example/console/example.dart
+++ b/example/console/example.dart
@@ -24,11 +24,11 @@ void main() async {
     final client = centrifuge.createClient(
       url,
       centrifuge.ClientConfig(
-        name: userName,
-        token: userJwtToken,
-        // Headers are only supported on platforms that support dart:io
-        headers: <String, dynamic>{'X-Example-Header': 'example'},
-      ),
+          name: userName,
+          token: userJwtToken,
+          // Headers are only supported on platforms that support dart:io
+          headers: <String, dynamic>{'X-Example-Header': 'example'},
+          minReconnectDelay: Duration(milliseconds: 50)),
     );
 
     // State changes.
@@ -50,11 +50,11 @@ void main() async {
     final subscription = client.newSubscription(
       channel,
       centrifuge.SubscriptionConfig(
-        token: subscriptionJwtToken,
-        // getToken: (centrifuge.SubscriptionTokenEvent event) {
-        //   return Future.value('');
-        // },
-      ),
+          // token: subscriptionJwtToken,
+          // getToken: (centrifuge.SubscriptionTokenEvent event) {
+          //   return Future.value('');
+          // },
+          ),
     );
 
     final onSubscriptionEvent = (dynamic event) async {
@@ -89,8 +89,8 @@ void main() async {
   }
 }
 
-Function(String) _handleUserInput(
-    centrifuge.Client client, centrifuge.Subscription subscription) {
+Function(String) _handleUserInput(centrifuge.Client client, centrifuge.Subscription subscription) {
+  var c = 0;
   return (String message) async {
     switch (message) {
       case '#subscribe':
@@ -121,24 +121,28 @@ Function(String) _handleUserInput(
         break;
       case '#history':
         final result = await subscription.history(limit: 10);
-        print('History num publications: ' +
-            result.publications.length.toString());
-        print('Stream top position: ' +
-            result.offset.toString() +
-            ', epoch: ' +
-            result.epoch);
+        print('History num publications: ' + result.publications.length.toString());
+        print('Stream top position: ' + result.offset.toString() + ', epoch: ' + result.epoch);
         break;
       case '#disconnect':
         await client.disconnect();
         break;
       default:
-        final output = jsonEncode({'input': message});
-        final data = utf8.encode(output);
-        try {
-          await subscription.publish(data);
-        } catch (ex) {
-          print("can't publish: $ex");
+        if (c % 2 == 0) {
+          print("DISCONNECT");
+          await subscription.unsubscribe();
+        } else {
+          print("CONNECT");
+          await subscription.subscribe();
         }
+        c += 1;
+        // final output = jsonEncode({'input': message});
+        // final data = utf8.encode(output);
+        // try {
+        //   await subscription.publish(data);
+        // } catch (ex) {
+        //   print("can't publish: $ex");
+        // }
         break;
     }
     return;

--- a/example/console/example.dart
+++ b/example/console/example.dart
@@ -128,21 +128,13 @@ Function(String) _handleUserInput(centrifuge.Client client, centrifuge.Subscript
         await client.disconnect();
         break;
       default:
-        if (c % 2 == 0) {
-          print("DISCONNECT");
-          await subscription.unsubscribe();
-        } else {
-          print("CONNECT");
-          await subscription.subscribe();
+        final output = jsonEncode({'input': message});
+        final data = utf8.encode(output);
+        try {
+          await subscription.publish(data);
+        } catch (ex) {
+          print("can't publish: $ex");
         }
-        c += 1;
-        // final output = jsonEncode({'input': message});
-        // final data = utf8.encode(output);
-        // try {
-        //   await subscription.publish(data);
-        // } catch (ex) {
-        //   print("can't publish: $ex");
-        // }
         break;
     }
     return;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -313,7 +313,6 @@ class ClientImpl implements Client {
 
   Future<void> _processDisconnect(
       {required int code, required String reason, required bool reconnect}) async {
-    print(state);
     if (state == State.disconnected) {
       return;
     }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -756,7 +756,7 @@ class ClientImpl implements Client {
           protocol.Command(),
         );
       } on ClientDisconnectedError {
-        //
+        // No need to handle in special way - pong can't be sent but connection is closed anyway.
       }
     }
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -756,7 +756,7 @@ class ClientImpl implements Client {
           protocol.Command(),
         );
       } on ClientDisconnectedError {
-        // No need to handle in special way - pong can't be sent but connection is closed anyway.
+        // No need to handle in a special way - pong can't be sent but connection is closed anyway.
       }
     }
   }

--- a/lib/src/error.dart
+++ b/lib/src/error.dart
@@ -11,13 +11,6 @@ class Error {
   }
 }
 
-class ClientConnectingError {
-  @override
-  String toString() {
-    return 'Client connecting';
-  }
-}
-
 class ClientDisconnectedError {
   @override
   String toString() {
@@ -25,24 +18,10 @@ class ClientDisconnectedError {
   }
 }
 
-class SubscriptionSubscribingError {
-  @override
-  String toString() {
-    return 'Subscription subscribing';
-  }
-}
-
 class SubscriptionUnsubscribedError {
   @override
   String toString() {
     return 'Subscription unsubscribed';
-  }
-}
-
-class SubscriptionFailedError {
-  @override
-  String toString() {
-    return 'Subscription failed';
   }
 }
 

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -109,7 +109,7 @@ class SubscriptionImpl implements Subscription {
       return;
     }
     if (state == SubscriptionState.subscribing) {
-      throw SubscriptionSubscribingError();
+      return ready();
     }
     _resubscribeAttempts = 0;
     state = SubscriptionState.subscribing;

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -31,8 +31,7 @@ abstract class Subscription {
   Future<PublishResult> publish(List<int> data);
   Future<PresenceResult> presence();
   Future<PresenceStatsResult> presenceStats();
-  Future<HistoryResult> history(
-      {int limit = 0, StreamPosition? since, bool reverse = false});
+  Future<HistoryResult> history({int limit = 0, StreamPosition? since, bool reverse = false});
 
   /// Ready resolves when subscription successfully subscribed.
   /// Throws exceptions if called not in subscribing or subscribed state.
@@ -73,18 +72,13 @@ class SubscriptionImpl implements Subscription {
   final ClientImpl _client;
   final SubscriptionConfig _config;
 
-  final _publicationController =
-      StreamController<PublicationEvent>.broadcast(sync: true);
+  final _publicationController = StreamController<PublicationEvent>.broadcast(sync: true);
   final _joinController = StreamController<JoinEvent>.broadcast(sync: true);
   final _leaveController = StreamController<LeaveEvent>.broadcast(sync: true);
-  final _subscribingController =
-      StreamController<SubscribingEvent>.broadcast(sync: true);
-  final _subscribedController =
-      StreamController<SubscribedEvent>.broadcast(sync: true);
-  final _unsubscribedController =
-      StreamController<UnsubscribedEvent>.broadcast(sync: true);
-  final _errorController =
-      StreamController<SubscriptionErrorEvent>.broadcast(sync: true);
+  final _subscribingController = StreamController<SubscribingEvent>.broadcast(sync: true);
+  final _subscribedController = StreamController<SubscribedEvent>.broadcast(sync: true);
+  final _unsubscribedController = StreamController<UnsubscribedEvent>.broadcast(sync: true);
+  final _errorController = StreamController<SubscriptionErrorEvent>.broadcast(sync: true);
 
   final _readyFutures = <Completer<void>>[];
 
@@ -119,16 +113,14 @@ class SubscriptionImpl implements Subscription {
     }
     _resubscribeAttempts = 0;
     state = SubscriptionState.subscribing;
-    final event =
-        SubscribingEvent(subscribingCodeSubscribeCalled, 'subscribe called');
+    final event = SubscribingEvent(subscribingCodeSubscribeCalled, 'subscribe called');
     _subscribingController.add(event);
     await _subscribe();
   }
 
   @override
   Future<void> unsubscribe() async {
-    return moveToUnsubscribed(
-        unsubscribedCodeUnsubscribeCalled, 'unsubscribe called', true);
+    return moveToUnsubscribed(unsubscribedCodeUnsubscribeCalled, 'unsubscribe called', true);
   }
 
   @internal
@@ -143,8 +135,7 @@ class SubscriptionImpl implements Subscription {
   }
 
   @internal
-  Future<void> moveToUnsubscribed(
-      int code, String reason, bool sendUnsubscribe) async {
+  Future<void> moveToUnsubscribed(int code, String reason, bool sendUnsubscribe) async {
     if (state == SubscriptionState.unsubscribed) {
       return;
     }
@@ -155,17 +146,12 @@ class SubscriptionImpl implements Subscription {
     if (prevState == SubscriptionState.subscribed) {
       _clearSubscribedState();
     }
-    if (sendUnsubscribe &&
-        prevState == SubscriptionState.subscribed &&
-        _client.state == State.connected) {
+    if (sendUnsubscribe && prevState == SubscriptionState.subscribed && _client.state == State.connected) {
       try {
-        await _client
-            .sendUnsubscribe(protocol.UnsubscribeRequest()..channel = channel);
+        await _client.sendUnsubscribe(protocol.UnsubscribeRequest()..channel = channel);
       } on Exception {
         _client.processDisconnect(
-            code: connectingCodeUnsubscribeError,
-            reason: 'unsubscribe error',
-            reconnect: true);
+            code: connectingCodeUnsubscribeError, reason: 'unsubscribe error', reconnect: true);
         _client.closeTransport();
         return;
       }
@@ -193,11 +179,9 @@ class SubscriptionImpl implements Subscription {
   }
 
   @override
-  Future<HistoryResult> history(
-      {int limit = 0, StreamPosition? since, bool reverse = false}) async {
+  Future<HistoryResult> history({int limit = 0, StreamPosition? since, bool reverse = false}) async {
     await ready().timeout(_client.config.timeout);
-    return _client.history(channel,
-        limit: limit, since: since, reverse: reverse);
+    return _client.history(channel, limit: limit, since: since, reverse: reverse);
   }
 
   @override
@@ -240,11 +224,9 @@ class SubscriptionImpl implements Subscription {
     _readyFutures.clear();
   }
 
-  void _addUnsubscribe(UnsubscribedEvent event) =>
-      _unsubscribedController.add(event);
+  void _addUnsubscribe(UnsubscribedEvent event) => _unsubscribedController.add(event);
 
-  void _addSubscribing(SubscribingEvent event) =>
-      _subscribingController.add(event);
+  void _addSubscribing(SubscribingEvent event) => _subscribingController.add(event);
 
   void _refreshToken() async {
     try {
@@ -261,8 +243,7 @@ class SubscriptionImpl implements Subscription {
       }
       final event = SubscriptionErrorEvent(SubscriptionRefreshError(ex));
       _errorController.add(event);
-      _refreshTimer = Timer(
-          backoffDelay(0, Duration(seconds: 5), Duration(seconds: 10)), () {
+      _refreshTimer = Timer(backoffDelay(0, Duration(seconds: 5), Duration(seconds: 10)), () {
         if (state != SubscriptionState.subscribed) {
           return;
         }
@@ -292,8 +273,7 @@ class SubscriptionImpl implements Subscription {
       _errorController.add(event);
       if (err is Error) {
         if (err.temporary) {
-          _refreshTimer = Timer(
-              backoffDelay(0, Duration(seconds: 5), Duration(seconds: 10)), () {
+          _refreshTimer = Timer(backoffDelay(0, Duration(seconds: 5), Duration(seconds: 10)), () {
             if (state != SubscriptionState.subscribed) {
               return;
             }
@@ -304,8 +284,7 @@ class SubscriptionImpl implements Subscription {
         moveToUnsubscribed(err.code, err.message, true);
         return;
       }
-      _refreshTimer = Timer(
-          backoffDelay(0, Duration(seconds: 5), Duration(seconds: 10)), () {
+      _refreshTimer = Timer(backoffDelay(0, Duration(seconds: 5), Duration(seconds: 10)), () {
         if (state != SubscriptionState.subscribed) {
           return;
         }
@@ -366,14 +345,11 @@ class SubscriptionImpl implements Subscription {
       }
     } on TimeoutException {
       _client.processDisconnect(
-          code: connectingCodeSubscribeTimeout,
-          reason: 'subscribe timeout',
-          reconnect: true);
+          code: connectingCodeSubscribeTimeout, reason: 'subscribe timeout', reconnect: true);
       _client.closeTransport();
       return;
     } catch (err) {
-      if (state != SubscriptionState.subscribing ||
-          _client.state != State.connected) {
+      if (state != SubscriptionState.subscribing || _client.state != State.connected) {
         return;
       }
       final event = SubscriptionErrorEvent(SubscriptionSubscribeError(err));
@@ -397,8 +373,8 @@ class SubscriptionImpl implements Subscription {
   }
 
   void _scheduleResubscribe() {
-    final Duration delay = backoffDelay(_resubscribeAttempts,
-        _config.minResubscribeDelay, _config.maxResubscribeDelay);
+    final Duration delay =
+        backoffDelay(_resubscribeAttempts, _config.minResubscribeDelay, _config.maxResubscribeDelay);
     _resubscribeTimer = Timer(delay, () {
       if (state != SubscriptionState.subscribing) {
         return;

--- a/lib/src/transport.dart
+++ b/lib/src/transport.dart
@@ -19,7 +19,7 @@ typedef WebSocketBuilder = Future<WebSocketChannel> Function();
 class TransportConfig {
   TransportConfig({
     this.headers = const <String, dynamic>{},
-    this.timeout = const Duration(seconds: 10),
+    this.timeout = const Duration(seconds: 5),
   });
 
   final Map<String, dynamic> headers;
@@ -52,15 +52,13 @@ Transport protobufTransportBuilder({
 }
 
 abstract class GeneratedMessageSender {
-  Future<Rep>
-      sendMessage<Req extends GeneratedMessage, Rep extends GeneratedMessage>(
-          Req request, Rep result);
+  Future<Rep> sendMessage<Req extends GeneratedMessage, Rep extends GeneratedMessage>(
+      Req request, Rep result);
   Future<void> sendAsyncMessage<Req extends GeneratedMessage>(Req request);
 }
 
 class Transport implements GeneratedMessageSender {
-  Transport(this._socketBuilder, this._config, this._commandEncoder,
-      this._replyDecoder);
+  Transport(this._socketBuilder, this._config, this._commandEncoder, this._replyDecoder);
 
   final WebSocketBuilder _socketBuilder;
   WebSocketChannel? _socket;
@@ -69,8 +67,7 @@ class Transport implements GeneratedMessageSender {
   final TransportConfig _config;
 
   Future open(void onPush(Push push, bool isPing),
-      {Function? onError,
-      void onDone(int code, String reason, bool shouldReconnect)?}) async {
+      {Function? onError, void onDone(int code, String reason, bool shouldReconnect)?}) async {
     final socket = await _socketBuilder();
     _socket = socket;
     socket.stream.listen(
@@ -85,8 +82,7 @@ class Transport implements GeneratedMessageSender {
   var _completers = <int, Completer<GeneratedMessage>>{};
 
   @override
-  Future<Rep>
-      sendMessage<Req extends GeneratedMessage, Rep extends GeneratedMessage>(
+  Future<Rep> sendMessage<Req extends GeneratedMessage, Rep extends GeneratedMessage>(
     Req request,
     Rep result,
   ) async {
@@ -101,8 +97,7 @@ class Transport implements GeneratedMessageSender {
       }
       final reply = await fut;
       if (reply.hasError()) {
-        throw centrifuge.Error.custom(
-            reply.error.code, reply.error.message, reply.error.temporary);
+        throw centrifuge.Error.custom(reply.error.code, reply.error.message, reply.error.temporary);
       }
       if (reply.hasConnect()) {
         result.mergeFromMessage(reply.connect);
@@ -209,13 +204,13 @@ class Transport implements GeneratedMessageSender {
   Future<Reply> _sendCommand(Command command) {
     final completer = Completer<Reply>.sync();
 
-    _completers[command.id] = completer;
-
-    final data = _commandEncoder.convert(command);
-
     if (_socket == null) {
       throw centrifuge.ClientDisconnectedError;
     }
+
+    _completers[command.id] = completer;
+
+    final data = _commandEncoder.convert(command);
 
     _socket!.sendData(data);
 
@@ -231,15 +226,12 @@ class Transport implements GeneratedMessageSender {
       int code = connectingCodeTransportClosed;
       String reason = "transport closed";
       bool reconnect = true;
-      if (_socket != null &&
-          _socket!.closeCode != null &&
-          _socket!.closeCode! > 0) {
+      if (_socket != null && _socket!.closeCode != null && _socket!.closeCode! > 0) {
         code = _socket!.closeCode!;
         if (_socket!.closeReason != null) {
           reason = _socket!.closeReason!;
         }
-        reconnect =
-            code < 3500 || code >= 5000 || (code >= 4000 && code < 4500);
+        reconnect = code < 3500 || code >= 5000 || (code >= 4000 && code < 4500);
         if (code < 3000) {
           if (code == 1009) {
             code = disconnectCodeMessageSizeLimit;


### PR DESCRIPTION
This should generally improve reconnect process by only scheduling reconnect routine in onDone handler of the transport. Thus reducing a chance of leaking connections. Also addresses #76 – no exception should be raised when pong message can't be written to closed transport.