### PR TITLE
Get data from config instead of pass it into class

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -100,7 +100,6 @@ abstract class Client {
 class ClientImpl implements Client {
   ClientImpl(this._url, this._config, this._transportBuilder) {
     _token = _config.token;
-    _data = _config.data;
   }
 
   final TransportBuilder _transportBuilder;
@@ -114,7 +113,7 @@ class ClientImpl implements Client {
   ClientConfig get config => _config;
 
   String _token = '';
-  List<int>? _data;
+  List<int>? get _data => _config.data;
   String? _client;
   String? get client => _client;
 


### PR DESCRIPTION
### When config has data getter instead of fixed value, it has no chance to update on connection lost and reconnect
That PR fixes that behavior