### PR TITLE
Add renew connection data callback

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -463,8 +463,9 @@ class ClientImpl implements Client {
     if (_token != '') {
       request.token = _token;
     }
-    if (_data != null) {
-      request.data = _data!;
+    final data = _config.getData != null ? await _config.getData!() : _data;
+    if (data != null) {
+      request.data = data;
     }
     request.name = _config.name;
     request.version = _config.version;

--- a/lib/src/client_config.dart
+++ b/lib/src/client_config.dart
@@ -13,6 +13,7 @@ class ClientConfig {
     this.token = '',
     this.getToken,
     this.data,
+    this.getData,
     this.headers = const <String, dynamic>{},
     this.tlsSkipVerify = false,
     this.timeout = const Duration(seconds: 10),
@@ -31,6 +32,9 @@ class ClientConfig {
 
   /// The data send for the first request
   List<int>? data;
+
+  /// Callback to get/renew connection data
+  final ConnectionDataCallback? getData;
 
   /// The connection timeout
   final Duration timeout;
@@ -53,3 +57,5 @@ class ClientConfig {
 }
 
 typedef ConnectionTokenCallback = Future<String> Function(ConnectionTokenEvent);
+
+typedef ConnectionDataCallback = Future<List<int>?>? Function();


### PR DESCRIPTION
Hi! Currently it is possible to set connection data only when creating a class instance. My changes allow changing this data on the fly at any time.