### PR TITLE
Wire ClientConfig.tlsSkipVerify through to the WebSocket transport

### DIFF
--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -1,17 +1,31 @@
+import 'dart:io';
+
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
-/// Connects the web socket channel
+/// Connects the web socket channel.
+///
+/// On VM/Flutter (non-web) platforms, [tlsSkipVerify]=true installs a
+/// custom [HttpClient] whose [HttpClient.badCertificateCallback] accepts
+/// every certificate. Useful for development against a server with a
+/// self-signed cert. Has no effect for `ws://` URLs.
 WebSocketChannel connect(
   Uri uri, {
   Iterable<String>? protocols,
   Map<String, dynamic>? headers,
-}) =>
-    IOWebSocketChannel.connect(
-      uri,
-      protocols: protocols,
-      headers: headers,
-    );
+  bool tlsSkipVerify = false,
+}) {
+  HttpClient? customClient;
+  if (tlsSkipVerify) {
+    customClient = HttpClient()..badCertificateCallback = (_, __, ___) => true;
+  }
+  return IOWebSocketChannel.connect(
+    uri,
+    protocols: protocols,
+    headers: headers,
+    customClient: customClient,
+  );
+}
 
 /// Extends the web socket channel
 extension WebSocketChannelExtension on WebSocketChannel {

--- a/lib/src/channel_html.dart
+++ b/lib/src/channel_html.dart
@@ -3,11 +3,17 @@ import 'dart:typed_data';
 import 'package:web_socket_channel/html.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
-/// Connects the web socket channel
+/// Connects the web socket channel.
+///
+/// [tlsSkipVerify] is accepted for API parity with the VM channel but is a
+/// no-op on the web: TLS certificate validation is owned by the browser
+/// and cannot be overridden from JavaScript. To use a self-signed cert in
+/// the browser, trust it at the OS / browser level.
 WebSocketChannel connect(
   Uri uri, {
   Iterable<String>? protocols,
   Map<String, dynamic>? headers,
+  bool tlsSkipVerify = false,
 }) =>
     HtmlWebSocketChannel.connect(
       uri,

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -434,8 +434,12 @@ class ClientImpl implements Client {
       return;
     }
 
-    final transport =
-        _transportBuilder(url: _url, config: TransportConfig(headers: _headers, timeout: _config.timeout));
+    final transport = _transportBuilder(
+        url: _url,
+        config: TransportConfig(
+            headers: _headers,
+            timeout: _config.timeout,
+            tlsSkipVerify: _config.tlsSkipVerify));
 
     try {
       await transport.open(_onPush, onError: (dynamic error) {

--- a/lib/src/client_config.dart
+++ b/lib/src/client_config.dart
@@ -46,6 +46,14 @@ class ClientConfig {
   /// translated to HTTP headers by Centrifugo in the proxy request to the backend.
   final Map<String, String> headers;
 
+  /// When true, skip TLS certificate verification on the WebSocket
+  /// upgrade request — useful for `wss://` development against a server
+  /// with a self-signed certificate.
+  ///
+  /// Only honored on VM/Flutter (`dart:io`) platforms; ignored in the
+  /// browser, where TLS validation is owned by the browser and cannot be
+  /// overridden from JavaScript. To trust a self-signed cert in the
+  /// browser, install it at the OS / browser level.
   final bool tlsSkipVerify;
   final Duration minReconnectDelay;
   final Duration maxReconnectDelay;

--- a/lib/src/transport.dart
+++ b/lib/src/transport.dart
@@ -20,10 +20,12 @@ class TransportConfig {
   TransportConfig({
     this.headers = const <String, dynamic>{},
     this.timeout = const Duration(seconds: 5),
+    this.tlsSkipVerify = false,
   });
 
   final Map<String, dynamic> headers;
   final Duration timeout;
+  final bool tlsSkipVerify;
 }
 
 Transport protobufTransportBuilder({
@@ -39,6 +41,7 @@ Transport protobufTransportBuilder({
         Uri.parse(url),
         protocols: ['centrifuge-protobuf'],
         headers: config.headers,
+        tlsSkipVerify: config.tlsSkipVerify,
       );
       await channel.ready;
       return channel;


### PR DESCRIPTION
## Summary

`ClientConfig.tlsSkipVerify` has existed in the public API for some time but was never read anywhere in the library, so users setting it for `wss://` against a self-signed cert silently got full certificate verification anyway. This PR wires it through.

- **VM / Flutter (`dart:io` platforms):** the channel now installs a custom `HttpClient` whose `badCertificateCallback` accepts every certificate when `tlsSkipVerify: true`. Threaded through `TransportConfig` and the existing platform-conditional `channel.connect()` shim. Useful for development against a server with a self-signed cert.
- **Web:** the option is accepted for API parity but is a no-op. TLS validation in browsers is owned by the browser / OS trust store and cannot be overridden from JavaScript. To trust a self-signed cert in the browser, install it at the OS / browser level. The web channel ignores the flag, and the dartdoc on `ClientConfig.tlsSkipVerify` calls this out.

Independent of #106 — applies cleanly on its own.

## Test plan

- [x] `dart analyze lib/` clean
- [x] `dart test` — all 30 existing tests still pass
- [ ] Manual verification of the VM path against a Centrifugo with a self-signed cert is recommended before release; an integration test using a self-signed cert was scoped out for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)