### PR TITLE
Fix connection and subscription stability bugs

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -342,7 +342,7 @@ class ClientImpl implements Client {
   @override
   Future<void> send(List<int> data) async {
     await ready().timeout(_config.timeout);
-    final request = protocol.Message()..data = data;
+    final request = protocol.SendRequest()..data = data;
     await _transport!.sendAsyncMessage(request);
   }
 
@@ -476,7 +476,7 @@ class ClientImpl implements Client {
   }
 
   Future<void> _connectInner() async {
-    if (_refreshRequired || (_token == '' && _config.getToken != null)) {
+    if (_config.getToken != null && (_refreshRequired || _token == '')) {
       final event = ConnectionTokenEvent();
       try {
         final String token = await _config.getToken!(event);
@@ -487,6 +487,7 @@ class ClientImpl implements Client {
           await _failUnauthorized();
           return;
         }
+        if (_closed) return;
         final event = ErrorEvent(RefreshError(ex));
         _errorController.add(event);
         if (state == State.connecting) {
@@ -509,13 +510,13 @@ class ClientImpl implements Client {
 
     try {
       await transport.open(_onPush, onError: (dynamic error) {
+        if (_closed) return;
         final event = ErrorEvent(TransportError(error));
         _errorController.add(event);
         if (state != State.connected) {
           return;
         }
         _processDisconnect(code: connectingCodeTransportClosed, reason: "connection closed", reconnect: true);
-        transport.close();
       }, onDone: (code, reason, reconnect) {
         if (state == State.disconnected) {
           return;
@@ -526,6 +527,7 @@ class ClientImpl implements Client {
         }
       });
     } catch (ex) {
+      if (_closed) return;
       final event = ErrorEvent(TransportError(ex));
       _errorController.add(event);
       if (state == State.connecting) {
@@ -543,7 +545,21 @@ class ClientImpl implements Client {
     if (_token != '') {
       request.token = _token;
     }
-    final data = _config.getData != null ? await _config.getData!() : _data;
+    List<int>? data;
+    if (_config.getData != null) {
+      try {
+        data = await _config.getData!();
+      } catch (ex) {
+        if (!_closed) {
+          final event = ErrorEvent(TransportError(ex));
+          _errorController.add(event);
+        }
+        await transport.close();
+        return;
+      }
+    } else {
+      data = _data;
+    }
     if (data != null) {
       request.data = data;
     }
@@ -627,6 +643,18 @@ class ClientImpl implements Client {
       if (state != State.connecting) {
         return;
       }
+      if (err is ClientDisconnectedError) {
+        // Transport closed while the ConnectRequest was in flight. The
+        // transport's _onDone callback already called _processDisconnect +
+        // _scheduleReconnect (via Completer.sync(), _onDone runs its
+        // onDone!() call synchronously after completing our completer, so
+        // the reconnect timer is scheduled before this catch resumes). If
+        // we call _processDisconnect here it cancels that timer via
+        // _reconnectTimer?.cancel() without rescheduling, leaving the
+        // client stuck in connecting state. Return early and let the
+        // already-scheduled timer handle the reconnect.
+        return;
+      }
       final event = ErrorEvent(ConnectError(err));
       _errorController.add(event);
       if (err is Error) {
@@ -690,6 +718,10 @@ class ClientImpl implements Client {
         }
         _refreshToken();
       });
+      return;
+    }
+
+    if (state != State.connected) {
       return;
     }
 
@@ -825,12 +857,16 @@ class ClientImpl implements Client {
         // a full re-sync from the current head.
         subscription.invalidateState();
         subscription.moveToSubscribing(unsubscribe.code, unsubscribe.reason);
+        subscription.resubscribeOnConnect();
         return;
       }
       if (unsubscribe.code < 2500) {
         subscription.moveToUnsubscribed(unsubscribe.code, unsubscribe.reason, false);
       } else {
+        // Temporary server-side unsubscribe: client stays connected so we must
+        // trigger a resubscribe immediately rather than waiting for a reconnect.
         subscription.moveToSubscribing(unsubscribe.code, unsubscribe.reason);
+        subscription.resubscribeOnConnect();
       }
       return;
     }
@@ -934,6 +970,7 @@ Duration backoffDelay(int step, Duration minDelay, Duration maxDelay) {
     step = 31;
   } // Avoid RangeError.
   final val = min(maxDelay.inMilliseconds, minDelay.inMilliseconds * pow(2, step));
+  if (val.toInt() <= 0) return minDelay;
   final interval = _random.nextInt(val.toInt());
   final milliseconds = min(maxDelay.inMilliseconds, minDelay.inMilliseconds + interval);
   return Duration(milliseconds: milliseconds);

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -60,6 +60,8 @@ class SubscriptionImpl implements Subscription {
   // moveToUnsubscribed to decide whether the server-side subscription needs
   // an explicit cleanup UnsubscribeRequest if the user cancels mid-flight.
   bool _inflight = false;
+  bool _resubscribing = false;
+  bool _closed = false;
 
   SubscriptionImpl(this.channel, this._client, this._config) {
     _token = _config.token;
@@ -116,6 +118,9 @@ class SubscriptionImpl implements Subscription {
 
   @override
   Future<void> subscribe() async {
+    if (_closed) {
+      throw ClientClosedError();
+    }
     if (state == SubscriptionState.subscribed) {
       return;
     }
@@ -136,6 +141,11 @@ class SubscriptionImpl implements Subscription {
 
   @internal
   void close() {
+    _closed = true;
+    _resubscribeTimer?.cancel();
+    _refreshTimer?.cancel();
+    _errorReadyFutures(SubscriptionUnsubscribedError());
+    state = SubscriptionState.unsubscribed;
     _publicationController.close();
     _joinController.close();
     _leaveController.close();
@@ -197,6 +207,7 @@ class SubscriptionImpl implements Subscription {
           await _client.processDisconnect(
               code: connectingCodeUnsubscribeError, reason: 'unsubscribe error', reconnect: true);
           await _client.closeTransport();
+          _addUnsubscribe(UnsubscribedEvent(code, reason));
           return;
         }
       }
@@ -269,7 +280,9 @@ class SubscriptionImpl implements Subscription {
     _readyFutures.clear();
   }
 
-  void _addUnsubscribe(UnsubscribedEvent event) => _unsubscribedController.add(event);
+  void _addUnsubscribe(UnsubscribedEvent event) {
+    if (!_closed) _unsubscribedController.add(event);
+  }
 
   void _addSubscribing(SubscribingEvent event) => _subscribingController.add(event);
 
@@ -339,6 +352,8 @@ class SubscriptionImpl implements Subscription {
   }
 
   Future _resubscribe() async {
+    if (_resubscribing) return;
+    _resubscribing = true;
     try {
       var token = _token;
       if (token == '' && _config.getToken != null) {
@@ -349,6 +364,10 @@ class SubscriptionImpl implements Subscription {
           return;
         }
         _token = token;
+      }
+      if (state != SubscriptionState.subscribing || _client.state != State.connected) {
+        // unsubscribe() or disconnect() arrived during the getToken await.
+        return;
       }
       final request = protocol.SubscribeRequest()
         ..channel = channel
@@ -435,6 +454,8 @@ class SubscriptionImpl implements Subscription {
       }
       _scheduleResubscribe();
       return;
+    } finally {
+      _resubscribing = false;
     }
   }
 

--- a/lib/src/transport.dart
+++ b/lib/src/transport.dart
@@ -68,9 +68,11 @@ class Transport implements GeneratedMessageSender {
   final CommandEncoder _commandEncoder;
   final ReplyDecoder _replyDecoder;
   final TransportConfig _config;
+  Function? _onError;
 
   Future open(void onPush(Push push, bool isPing),
       {Function? onError, void onDone(int code, String reason, bool shouldReconnect)?}) async {
+    _onError = onError;
     final socket = await _socketBuilder();
     _socket = socket;
     socket.stream.listen(
@@ -254,7 +256,15 @@ class Transport implements GeneratedMessageSender {
 
   void Function(dynamic) _onData(void onPush(Push push, bool isPing)) {
     return (dynamic input) {
-      final List<Reply> replies = _replyDecoder.convert(input);
+      final List<Reply> replies;
+      try {
+        replies = _replyDecoder.convert(input);
+      } catch (e) {
+        if (_onError != null) {
+          _onError!(e);
+        }
+        return;
+      }
       replies.forEach((reply) {
         if (reply.id > 0) {
           _completers.remove(reply.id)?.complete(reply);

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1093,6 +1093,99 @@ void main() {
       expect(client.state, centrifuge.State.disconnected);
       expect(() => client.connect(), throwsA(isA<centrifuge.ClientClosedError>()));
     });
+
+    test('close errors pending ready() futures instead of leaking them', () async {
+      // Don't connect — subscription stays in subscribing indefinitely so
+      // there is no race between "subscribe completes" and "close() fires".
+      final client = createClient();
+
+      final sub = client.newSubscription(uniqueChannel('default'));
+      await sub.subscribe(); // moves to subscribing; no request sent (client not connected)
+
+      // Attach listener before close() so the error is never unhandled.
+      final readyDone = expectLater(
+          sub.ready(), throwsA(isA<centrifuge.SubscriptionUnsubscribedError>()));
+
+      await client.close(); // subscription.close() must error the pending ready()
+      await readyDone;
+    });
+
+    test('removeSubscription after close does not throw StateError', () async {
+      final client = createClient();
+      await client.connect();
+
+      final sub = client.newSubscription(uniqueChannel('default'));
+      await sub.subscribe();
+      await client.close();
+
+      // Before the fix, subscription.close() left state=subscribing with closed
+      // stream controllers. removeSubscription then called moveToUnsubscribed,
+      // which tried to emit on a closed controller → unhandled StateError.
+      await expectLater(client.removeSubscription(sub), completes);
+    });
+
+    test('unsubscribe during getToken does not create a server-side subscription', () async {
+      final client = createClient();
+      await client.connect();
+
+      final channel = uniqueChannel('default');
+
+      // Block getToken until we explicitly release it so we can call
+      // unsubscribe() while the token fetch is in progress.
+      final tokenCompleter = Completer<String>();
+
+      final sub = client.newSubscription(
+          channel,
+          centrifuge.SubscriptionConfig(
+            getToken: (_) => tokenCompleter.future,
+          ));
+
+      final publications = <centrifuge.PublicationEvent>[];
+      sub.publication.listen((p) => publications.add(p));
+
+      // Start subscribing — will block inside getToken.
+      // ignore: unawaited_futures
+      sub.subscribe();
+
+      // Unsubscribe while getToken is still pending.
+      await sub.unsubscribe();
+      expect(sub.state, centrifuge.SubscriptionState.unsubscribed);
+
+      // Release the token. Without the fix, _resubscribe() proceeds past the
+      // token block and sends a SubscribeRequest despite state=unsubscribed,
+      // leaving a server-side subscription that delivers publications.
+      tokenCompleter.complete('any-token');
+
+      // Give everything time to settle.
+      await Future<void>.delayed(Duration(milliseconds: 200));
+
+      // Publish to the channel from the server side.
+      await apiPublish(channel, {'msg': 'should-not-arrive'});
+      await Future<void>.delayed(Duration(milliseconds: 100));
+
+      // The subscription must still be unsubscribed and must not have received
+      // any publications from the spurious server-side subscription.
+      expect(sub.state, centrifuge.SubscriptionState.unsubscribed);
+      expect(publications, isEmpty);
+
+      await client.close();
+    });
+
+    test('subscribe() on a closed subscription throws SubscriptionUnsubscribedError',
+        () async {
+      final client = createClient();
+      await client.connect();
+
+      final sub = client.newSubscription(uniqueChannel('default'));
+      await sub.subscribe();
+      await client.close();
+
+      // After close(), the subscription is closed. subscribe() must throw a
+      // meaningful error rather than a StateError on a closed stream controller.
+      expect(
+          sub.subscribe(),
+          throwsA(isA<centrifuge.ClientClosedError>()));
+    });
   });
 
   group('Stream recovery (extended)', () {
@@ -1838,6 +1931,101 @@ void main() {
 
       await client.disconnect();
       expect(client.state, centrifuge.State.disconnected);
+    });
+  });
+
+  group('Reconnect reliability', () {
+    // connectAndCaptureId from the Server-initiated reconnection group is
+    // duplicated here because groups have independent scopes.
+    Future<String> connectAndCaptureId(centrifuge.Client client) async {
+      final completer = Completer<String>();
+      late StreamSubscription<centrifuge.ConnectedEvent> sub;
+      sub = client.connected.listen((e) {
+        if (!completer.isCompleted) completer.complete(e.client);
+        sub.cancel();
+      });
+      await client.connect();
+      return completer.future.timeout(const Duration(seconds: 5));
+    }
+
+    test(
+        'unsubscribed event fires even when connection drops during cleanup send',
+        () async {
+      // Regression test for: when sendUnsubscribe() throws because the
+      // transport closed mid-flight, moveToUnsubscribed must still emit
+      // UnsubscribedEvent. Previously the early return for the reconnect path
+      // skipped _addUnsubscribe, leaving the subscription silently dead.
+      //
+      // We race unsubscribe() against a server-initiated disconnect. In some
+      // runs the sendUnsubscribe reply arrives first (normal path); in others
+      // the connection drops before the reply (the previously broken path). In
+      // both cases UnsubscribedEvent must fire with code 0 and the subscription
+      // must stay unsubscribed after the client auto-reconnects.
+      final client = createClient(centrifuge.ClientConfig(
+        minReconnectDelay: const Duration(milliseconds: 50),
+      ));
+      final id = await connectAndCaptureId(client);
+
+      final ch = randomChannel('unsub-race');
+      final sub = client.newSubscription(ch);
+      await sub.subscribe();
+
+      final unsubFuture =
+          waitForEvent<centrifuge.UnsubscribedEvent>(sub.unsubscribed);
+      final reconnectedFuture =
+          waitForEvent<centrifuge.ConnectedEvent>(client.connected);
+
+      // Fire-and-forget unsubscribe then immediately drop the server
+      // connection. This races the sendUnsubscribe reply against the
+      // disconnect.
+      // ignore: unawaited_futures
+      sub.unsubscribe();
+      await apiDisconnectClient(id, code: 3001);
+
+      // UnsubscribedEvent must arrive regardless of which race path was taken.
+      final ctx =
+          await unsubFuture.timeout(const Duration(seconds: 5));
+      expect(ctx.code, 0); // unsubscribedCodeUnsubscribeCalled
+      expect(sub.state, centrifuge.SubscriptionState.unsubscribed);
+
+      // Client must auto-reconnect (3001 is retryable).
+      await reconnectedFuture.timeout(const Duration(seconds: 5));
+      expect(client.state, centrifuge.State.connected);
+
+      // Subscription must NOT be auto-resubscribed — the user explicitly
+      // called unsubscribe(), so that intent must survive the reconnect.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      expect(sub.state, centrifuge.SubscriptionState.unsubscribed,
+          reason: 'subscription must remain unsubscribed after reconnect');
+
+      await client.disconnect();
+    });
+
+    test('zero minReconnectDelay does not crash on retryable disconnect',
+        () async {
+      // Regression test for backoffDelay() panicking with RangeError when
+      // minReconnectDelay is Duration.zero: nextInt(0) is illegal. The guard
+      // added to backoffDelay() must return Duration.zero instead of throwing.
+      final client = centrifuge.createClient(
+        url,
+        centrifuge.ClientConfig(
+          minReconnectDelay: Duration.zero,
+          maxReconnectDelay: const Duration(milliseconds: 200),
+        ),
+      );
+      final id = await connectAndCaptureId(client);
+
+      final reconnected =
+          waitForEvent<centrifuge.ConnectedEvent>(client.connected);
+
+      // A retryable server disconnect triggers _scheduleReconnect →
+      // backoffDelay(0, Duration.zero, ...). Without the fix this panics.
+      await apiDisconnectClient(id, code: 3001);
+
+      await reconnected.timeout(const Duration(seconds: 5));
+      expect(client.state, centrifuge.State.connected);
+
+      await client.disconnect();
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR fixes several bugs that could cause stuck reconnect loops, missed resubscriptions, crashes, and silent event loss under realistic concurrency conditions.

---

## Bugs fixed

### 1. Client stuck in `connecting` state after transport closes mid-connect

When the WebSocket closed while a `ConnectRequest` was in flight, the transport's
`_onDone` callback ran synchronously (via `Completer.sync()`), calling
`_processDisconnect` + `_scheduleReconnect` before the `catch` block in
`_connectInner` resumed. The `catch` then called `_processDisconnect` a second
time, which cancelled the already-scheduled reconnect timer without rescheduling
one, leaving the client permanently stuck in `connecting`.

**Fix:** Return early from `_connectInner`'s catch when the error is
`ClientDisconnectedError`; the reconnect timer is already running.

---

### 2. Server-initiated temporary unsubscribe did not trigger resubscription

When the server sent an `Unsubscribe` push with code ≥ 2500 (temporary, e.g. code
2502 for state invalidation), `_handleUnsubscribe` called `moveToSubscribing` to
transition the subscription but never attempted a resubscribe. Unlike a full
disconnect, the client remains connected in this case, so waiting for a reconnect
means the subscription never recovers.

**Fix:** Call `resubscribeOnConnect()` after `moveToSubscribing()` for all
temporary server unsubscribes (code ≥ 2500 and the existing code 2502 path).

---

### 3. `_resubscribe` lacked a concurrency guard

`_resubscribe()` had no mutex, so concurrent calls (e.g. from a pending retry
timer firing at the same moment as `resubscribeOnConnect()` on reconnect) could
result in two simultaneous `SubscribeRequest`s for the same channel.

**Fix:** Added `_resubscribing` boolean flag (set/cleared in `try/finally`) that
causes any concurrent call to return immediately.

---

### 4. State not checked after `getToken` await in `_resubscribe`

After `await _config.getToken!(event)` yielded, a concurrent `unsubscribe()` or
disconnect could change the subscription state. The code proceeded to build and
send a `SubscribeRequest` regardless.

**Fix:** Added `if (state != subscribing || client.state != connected) return`
immediately after the `getToken` await.

---

### 5. `_addUnsubscribe` StateError on concurrent close + unsubscribe

When `client.close()` ran concurrently with `subscription.unsubscribe()`, the
`moveToUnsubscribed` future could resume after `subscription.close()` had already
closed `_unsubscribedController`. Calling `.add()` on a closed broadcast
`StreamController` throws `StateError`.

**Fix:** `_addUnsubscribe` now checks `!_closed` before adding to the stream.

---

### 6. `subscription.close()` did not clean up state before closing streams

`close()` closed the stream controllers but did not set `_closed = true`, cancel
pending timers, error out pending `ready()` futures, or set state to `unsubscribed`
first. This left a window where timer callbacks and async continuations could still
try to interact with the subscription after it was destroyed.

**Fix:** `close()` now sets `_closed = true`, cancels `_resubscribeTimer` and
`_refreshTimer`, calls `_errorReadyFutures`, and sets `state = unsubscribed` before
closing any controllers.

---

### 7. `subscribe()` did not guard against calling on a closed subscription

After `client.close()`, calling `subscription.subscribe()` would proceed past the
state check (state was unsubscribed but `_closed` was unset), producing confusing
errors downstream.

**Fix:** `subscribe()` now throws `ClientClosedError` when `_closed` is true.

---

### 8. Missing `UnsubscribedEvent` when unsubscribe cleanup send fails

In `moveToUnsubscribed`, if the cleanup `UnsubscribeRequest` to the server failed
and `prevState` was `subscribed`, the code triggered a reconnect and returned
early — but did so without emitting the `UnsubscribedEvent` to the caller. The
caller's `await unsubscribe()` would complete silently with no event on the stream.

**Fix:** Added `_addUnsubscribe(UnsubscribedEvent(code, reason))` before the early
return in that error path.

---

### 9. `_errorController.add` after `client.close()` in `_connectInner` (4 sites)

If `client.close()` ran while `_connectInner` was awaiting `getToken`, `transport.open`,
or `getData`, the continuation could fire after `_errorController` was closed,
causing a `StateError: Cannot add event after closing`.

**Fix:** Added `if (_closed) return` guards at all four affected sites:
- `getToken` exception catch
- `transport.open` `onError` callback
- `transport.open` exception catch
- `getData` exception catch

---

### 10. Transport decode errors crashed the stream listener

A malformed incoming frame caused `_replyDecoder.convert()` to throw, which
propagated uncaught through the WebSocket stream `onData` handler, killing the
listener and silently stopping all further message processing.

**Fix:** Wrapped `_replyDecoder.convert()` in a try/catch; decode errors are now
forwarded to the `onError` callback so the connection handles them gracefully.

---

### 11. `backoffDelay` panicked with `minReconnectDelay: Duration.zero`

When `minReconnectDelay` was zero, `val.toInt()` evaluated to `0` and
`Random.nextInt(0)` threw a `RangeError`.

**Fix:** Return `minDelay` immediately when `val <= 0`.

---

### 12. `_refreshToken` missing state check after `getToken` await

`_refreshToken()` on the client checked state before calling `getToken` but not
after. A disconnect during the `getToken` await could leave the client in a
non-connected state, yet `_refreshToken` would still proceed to send a
`RefreshRequest` against the (now-null) transport.

**Fix:** Added `if (state != State.connected) return` after the `getToken` await,
before the `RefreshRequest` is built.

---

### 13. `send()` used wrong protobuf message type

`Client.send()` was constructing `protocol.Message` instead of
`protocol.SendRequest`, causing a runtime `ArgumentError` from the transport's
command encoder on every call.

**Fix:** Changed to `protocol.SendRequest`.

---

### 14. `onError` callback called `transport.close()` redundantly

The `onError` handler inside `transport.open(...)` called `transport.close()`, but
by the time a stream error fires the transport is already in an error state and the
`onDone` path handles cleanup. The extra close caused a double-close and surfaced
as a spurious error event.

**Fix:** Removed the `transport.close()` call from the `onError` handler.

---

## Tests added

- `close()` errors pending `ready()` futures instead of leaking them
- `removeSubscription` after `close()` does not throw `StateError`
- `unsubscribe()` during `getToken` does not create a server-side subscription (validates `_inflight` cleanup path)
- `subscribe()` on a closed subscription throws `SubscriptionUnsubscribedError`
- Zero `minReconnectDelay` does not crash on retryable disconnect
