### PR TITLE
Support publication filtering by tags

### DIFF
--- a/lib/centrifuge.dart
+++ b/lib/centrifuge.dart
@@ -2,5 +2,6 @@ export 'src/client.dart' show Client, createClient, State;
 export 'src/client_config.dart';
 export 'src/error.dart';
 export 'src/events.dart';
+export 'src/filter.dart' show Filter, FilterNode;
 export 'src/subscription.dart' show Subscription, SubscriptionState;
 export 'src/subscription_config.dart';

--- a/lib/src/filter.dart
+++ b/lib/src/filter.dart
@@ -1,0 +1,103 @@
+import 'package:meta/meta.dart';
+
+import 'proto/client.pb.dart' as protocol;
+
+/// A node in a publication tags-filter expression tree, used for server-side
+/// publication filtering. Build instances with the [Filter] helpers and pass
+/// the result to [SubscriptionConfig.tagsFilter] or
+/// [Subscription.setTagsFilter].
+///
+/// A filter is either a leaf node (a comparison such as `ticker == "AAPL"`) or
+/// a logical node combining child nodes with `and` / `or` / `not`. The server
+/// evaluates the filter against each publication's tags and delivers only
+/// matching publications. See
+/// https://centrifugal.dev/docs/server/publication_filtering for details.
+///
+/// Publication filtering must be enabled for the namespace on the server
+/// (`allow_tags_filter`) and cannot be combined with delta compression.
+@immutable
+class FilterNode {
+  const FilterNode._(this._node);
+
+  final protocol.FilterNode _node;
+
+  /// The underlying protocol message. Internal — not part of the public API.
+  @internal
+  protocol.FilterNode get proto => _node;
+}
+
+/// Builders for publication tags-filter expressions. Comparison helpers create
+/// leaf nodes; [and], [or] and [not] combine them.
+///
+/// ```dart
+/// // (ticker == "AAPL") AND (price >= "100") AND (source in ["NASDAQ", "NYSE"])
+/// final filter = Filter.and([
+///   Filter.eq('ticker', 'AAPL'),
+///   Filter.gte('price', '100'),
+///   Filter.inList('source', ['NASDAQ', 'NYSE']),
+/// ]);
+/// ```
+abstract final class Filter {
+  static FilterNode _leaf(String key, String cmp, {String? val, List<String>? vals}) {
+    final node = protocol.FilterNode()
+      ..key = key
+      ..cmp = cmp;
+    if (val != null) node.val = val;
+    if (vals != null) node.vals.addAll(vals);
+    return FilterNode._(node);
+  }
+
+  static FilterNode _logical(String op, List<FilterNode> nodes) {
+    final node = protocol.FilterNode()..op = op;
+    node.nodes.addAll(nodes.map((n) => n.proto));
+    return FilterNode._(node);
+  }
+
+  /// Tag [key] equals [val].
+  static FilterNode eq(String key, String val) => _leaf(key, 'eq', val: val);
+
+  /// Tag [key] does not equal [val].
+  static FilterNode neq(String key, String val) => _leaf(key, 'neq', val: val);
+
+  /// Tag [key] is one of [vals].
+  static FilterNode inList(String key, List<String> vals) => _leaf(key, 'in', vals: vals);
+
+  /// Tag [key] is not one of [vals].
+  static FilterNode notInList(String key, List<String> vals) => _leaf(key, 'nin', vals: vals);
+
+  /// Tag [key] exists.
+  static FilterNode exists(String key) => _leaf(key, 'ex');
+
+  /// Tag [key] does not exist.
+  static FilterNode notExists(String key) => _leaf(key, 'nex');
+
+  /// Tag [key] (string) starts with [val].
+  static FilterNode startsWith(String key, String val) => _leaf(key, 'sw', val: val);
+
+  /// Tag [key] (string) ends with [val].
+  static FilterNode endsWith(String key, String val) => _leaf(key, 'ew', val: val);
+
+  /// Tag [key] (string) contains [val].
+  static FilterNode contains(String key, String val) => _leaf(key, 'ct', val: val);
+
+  /// Tag [key] (numeric) is greater than [val].
+  static FilterNode gt(String key, String val) => _leaf(key, 'gt', val: val);
+
+  /// Tag [key] (numeric) is greater than or equal to [val].
+  static FilterNode gte(String key, String val) => _leaf(key, 'gte', val: val);
+
+  /// Tag [key] (numeric) is less than [val].
+  static FilterNode lt(String key, String val) => _leaf(key, 'lt', val: val);
+
+  /// Tag [key] (numeric) is less than or equal to [val].
+  static FilterNode lte(String key, String val) => _leaf(key, 'lte', val: val);
+
+  /// All [nodes] must match.
+  static FilterNode and(List<FilterNode> nodes) => _logical('and', nodes);
+
+  /// At least one of [nodes] must match.
+  static FilterNode or(List<FilterNode> nodes) => _logical('or', nodes);
+
+  /// Inverts [node].
+  static FilterNode not(FilterNode node) => _logical('not', [node]);
+}

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -9,6 +9,7 @@ import 'client.dart';
 import 'codes.dart';
 import 'error.dart';
 import 'events.dart';
+import 'filter.dart';
 import 'proto/client.pb.dart' as protocol;
 import 'subscription_config.dart';
 
@@ -32,6 +33,11 @@ abstract class Subscription {
   Future<void> subscribe();
   Future<void> unsubscribe();
 
+  /// Sets the server-side publication tags filter. Applied on the next
+  /// subscribe attempt, not the current one. Pass null to clear it. Cannot be
+  /// combined with delta compression. Build with the [Filter] helpers.
+  void setTagsFilter(FilterNode? tagsFilter);
+
   Future<PublishResult> publish(List<int> data);
   Future<PresenceResult> presence();
   Future<PresenceStatsResult> presenceStats();
@@ -45,6 +51,7 @@ abstract class Subscription {
 class SubscriptionImpl implements Subscription {
   String _token = '';
   List<int>? _data;
+  FilterNode? _tagsFilter;
   Timer? _refreshTimer;
   Timer? _resubscribeTimer;
   int _resubscribeAttempts = 0;
@@ -69,6 +76,7 @@ class SubscriptionImpl implements Subscription {
   SubscriptionImpl(this.channel, this._client, this._config) {
     _token = _config.token;
     _data = _config.data;
+    _tagsFilter = _config.tagsFilter;
     _positioned = _config.positioned;
     _recoverable = _config.recoverable;
     _joinLeave = _config.joinLeave;
@@ -140,6 +148,14 @@ class SubscriptionImpl implements Subscription {
   @override
   Future<void> unsubscribe() async {
     return moveToUnsubscribed(unsubscribedCodeUnsubscribeCalled, 'unsubscribe called', true);
+  }
+
+  @override
+  void setTagsFilter(FilterNode? tagsFilter) {
+    if (tagsFilter != null && _config.delta == DeltaType.fossil) {
+      throw ArgumentError('cannot use delta and tagsFilter together');
+    }
+    _tagsFilter = tagsFilter;
   }
 
   @internal
@@ -432,6 +448,9 @@ class SubscriptionImpl implements Subscription {
       }
       if (_config.delta == DeltaType.fossil) {
         request.delta = "fossil";
+      }
+      if (_tagsFilter != null) {
+        request.tf = _tagsFilter!.proto;
       }
       request.positioned = _positioned;
       request.recoverable = _recoverable;

--- a/lib/src/subscription_config.dart
+++ b/lib/src/subscription_config.dart
@@ -1,4 +1,5 @@
 import 'events.dart';
+import 'filter.dart';
 
 /// Enum for supported delta encoding algorithms.
 enum DeltaType {
@@ -18,7 +19,10 @@ class SubscriptionConfig {
       this.minResubscribeDelay = const Duration(milliseconds: 500),
       this.maxResubscribeDelay = const Duration(milliseconds: 20000),
       this.delta = DeltaType.none,
-      this.getState});
+      this.tagsFilter,
+      this.getState})
+      : assert(tagsFilter == null || delta == DeltaType.none,
+            'cannot use delta and tagsFilter together');
 
   String token;
   final SubscriptionTokenCallback? getToken;
@@ -30,6 +34,12 @@ class SubscriptionConfig {
   final Duration minResubscribeDelay;
   final Duration maxResubscribeDelay;
   final DeltaType delta;
+
+  /// Server-side publication filter based on publication tags. When set, the
+  /// server delivers only publications whose tags match the filter. Must be
+  /// enabled for the namespace on the server (`allow_tags_filter`) and cannot
+  /// be combined with [delta]. Build with the [Filter] helpers.
+  final FilterNode? tagsFilter;
 
   /// Called to load the app's current state and stream position.
   /// Requires Centrifugo >= 6.8.0.

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -1,0 +1,139 @@
+import 'package:centrifuge/centrifuge.dart' as centrifuge;
+import 'package:centrifuge/src/proto/client.pb.dart' as protocol;
+import 'package:test/test.dart';
+
+import 'fake_server.dart';
+
+// Publication filtering (server-side filtering by publication tags). The Filter
+// builders construct a protocol FilterNode tree; the subscribe request carries
+// it in the `tf` field. The feature requires Centrifugo PRO / namespace config,
+// so wire-level behavior is exercised against the in-process FakeCentrifugoServer.
+
+void main() {
+  group('Filter builder', () {
+    test('comparison leaf nodes', () {
+      expect(centrifuge.Filter.eq('ticker', 'AAPL').proto,
+          predicate<protocol.FilterNode>((n) => n.key == 'ticker' && n.cmp == 'eq' && n.val == 'AAPL'));
+      expect(centrifuge.Filter.neq('source', 'TEST').proto,
+          predicate<protocol.FilterNode>((n) => n.cmp == 'neq' && n.val == 'TEST'));
+      expect(centrifuge.Filter.exists('price').proto,
+          predicate<protocol.FilterNode>((n) => n.cmp == 'ex' && !n.hasVal()));
+      expect(centrifuge.Filter.notExists('internal_id').proto,
+          predicate<protocol.FilterNode>((n) => n.cmp == 'nex'));
+      expect(centrifuge.Filter.startsWith('ticker', 'AA').proto,
+          predicate<protocol.FilterNode>((n) => n.cmp == 'sw' && n.val == 'AA'));
+      expect(centrifuge.Filter.endsWith('source', 'DAQ').proto,
+          predicate<protocol.FilterNode>((n) => n.cmp == 'ew'));
+      expect(centrifuge.Filter.contains('category', 'ec').proto,
+          predicate<protocol.FilterNode>((n) => n.cmp == 'ct'));
+      expect(centrifuge.Filter.gt('price', '100').proto,
+          predicate<protocol.FilterNode>((n) => n.cmp == 'gt' && n.val == '100'));
+      expect(centrifuge.Filter.gte('volume', '1000').proto,
+          predicate<protocol.FilterNode>((n) => n.cmp == 'gte'));
+      expect(centrifuge.Filter.lt('price', '200').proto,
+          predicate<protocol.FilterNode>((n) => n.cmp == 'lt'));
+      expect(centrifuge.Filter.lte('volume', '1000').proto,
+          predicate<protocol.FilterNode>((n) => n.cmp == 'lte'));
+    });
+
+    test('set membership nodes carry vals', () {
+      final inNode = centrifuge.Filter.inList('category', ['tech', 'finance']).proto;
+      expect(inNode.cmp, 'in');
+      expect(inNode.vals, ['tech', 'finance']);
+
+      final ninNode = centrifuge.Filter.notInList('ticker', ['MSFT', 'GOOGL']).proto;
+      expect(ninNode.cmp, 'nin');
+      expect(ninNode.vals, ['MSFT', 'GOOGL']);
+    });
+
+    test('logical nodes nest children', () {
+      final filter = centrifuge.Filter.and([
+        centrifuge.Filter.eq('ticker', 'AAPL'),
+        centrifuge.Filter.gte('price', '100'),
+        centrifuge.Filter.inList('source', ['NASDAQ', 'NYSE']),
+      ]).proto;
+      expect(filter.op, 'and');
+      expect(filter.nodes, hasLength(3));
+      expect(filter.nodes[0].key, 'ticker');
+      expect(filter.nodes[2].cmp, 'in');
+
+      final orNode = centrifuge.Filter.or([
+        centrifuge.Filter.eq('ticker', 'MSFT'),
+        centrifuge.Filter.eq('category', 'tech'),
+      ]).proto;
+      expect(orNode.op, 'or');
+      expect(orNode.nodes, hasLength(2));
+
+      final notNode = centrifuge.Filter.not(centrifuge.Filter.eq('source', 'NYSE')).proto;
+      expect(notNode.op, 'not');
+      expect(notNode.nodes, hasLength(1));
+      expect(notNode.nodes.first.cmp, 'eq');
+    });
+
+    test('delta and tagsFilter cannot be combined in config', () {
+      expect(
+        () => centrifuge.SubscriptionConfig(
+          delta: centrifuge.DeltaType.fossil,
+          tagsFilter: centrifuge.Filter.eq('ticker', 'AAPL'),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('Tags filter wire', () {
+    late FakeCentrifugoServer server;
+    late centrifuge.Client client;
+
+    setUp(() async {
+      server = FakeCentrifugoServer();
+      await server.start();
+      client = centrifuge.createClient(server.url, centrifuge.ClientConfig());
+    });
+
+    tearDown(() async {
+      await client.close();
+      await server.stop();
+    });
+
+    test('subscribe request carries the tags filter', () async {
+      await client.connect();
+      final sub = client.newSubscription(
+        'market:stocks',
+        centrifuge.SubscriptionConfig(
+          tagsFilter: centrifuge.Filter.and([
+            centrifuge.Filter.eq('ticker', 'AAPL'),
+            centrifuge.Filter.gte('price', '100'),
+          ]),
+        ),
+      );
+      await sub.subscribe();
+
+      final tf = server.lastSubscribe!.tf;
+      expect(tf.op, 'and');
+      expect(tf.nodes, hasLength(2));
+      expect(tf.nodes[0].key, 'ticker');
+      expect(tf.nodes[0].cmp, 'eq');
+      expect(tf.nodes[0].val, 'AAPL');
+      expect(tf.nodes[1].cmp, 'gte');
+    });
+
+    test('setTagsFilter applies on next subscribe', () async {
+      await client.connect();
+      final sub = client.newSubscription('market:stocks', centrifuge.SubscriptionConfig());
+      sub.setTagsFilter(centrifuge.Filter.eq('ticker', 'BTC'));
+      await sub.subscribe();
+
+      expect(server.lastSubscribe!.hasTf(), isTrue);
+      expect(server.lastSubscribe!.tf.key, 'ticker');
+      expect(server.lastSubscribe!.tf.val, 'BTC');
+    });
+
+    test('subscribe without filter sends no tf', () async {
+      await client.connect();
+      final sub = client.newSubscription('market:stocks', centrifuge.SubscriptionConfig());
+      await sub.subscribe();
+      expect(server.lastSubscribe!.hasTf(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Adds support for [publication filtering](https://centrifugal.dev/docs/server/publication_filtering) by publication tags.

A subscription can carry a tags filter so the server delivers only publications whose tags match it — reducing bandwidth and client-side processing.

### API

- `Filter` builders: `eq`, `neq`, `inList`, `notInList`, `exists`, `notExists`, `startsWith`, `endsWith`, `contains`, `gt`, `gte`, `lt`, `lte`, `and`, `or`, `not`.
- `SubscriptionConfig.tagsFilter` to set at creation.
- `Subscription.setTagsFilter(...)` to set/replace before the next subscribe (pass `null` to clear).
- Mutually exclusive with delta compression (validated).

### Example

```dart
final sub = client.newSubscription('market:stocks', SubscriptionConfig(
  tagsFilter: Filter.and([
    Filter.eq('ticker', 'AAPL'),
    Filter.gte('price', '100'),
  ]),
));
```

Tests added in `test/filter_test.dart`: builder unit tests plus fake-server wire tests asserting the subscribe request carries the `tf` field (and sends none when unset).
