### PR TITLE
Add test for setTagsFilter delta compression guard

### DIFF
--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -135,5 +135,16 @@ void main() {
       await sub.subscribe();
       expect(server.lastSubscribe!.hasTf(), isFalse);
     });
+
+    test('setTagsFilter throws when subscription uses delta compression', () async {
+      final sub = client.newSubscription(
+        'market:stocks',
+        centrifuge.SubscriptionConfig(delta: centrifuge.DeltaType.fossil),
+      );
+      expect(
+        () => sub.setTagsFilter(centrifuge.Filter.eq('ticker', 'AAPL')),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- `Subscription.setTagsFilter()` throws `ArgumentError` when called on a subscription configured with `DeltaType.fossil` (tags filtering and delta compression can't be combined), but this runtime guard (`lib/src/subscription.dart:154-159`) had no test exercising it.
- The equivalent guard on the `SubscriptionConfig` constructor is already covered (`delta and tagsFilter cannot be combined in config` in `test/filter_test.dart`), so this closes the matching gap for the setter path.

## Test plan
- `dart test test/filter_test.dart` — all 9 tests pass, including the new one.