### PR TITLE
Remove redundant map re-assignment in server subscription offset update

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -816,7 +816,6 @@ class ClientImpl implements Client {
       _publicationController.add(event);
       if (serverSubscription.recoverable && pub.offset > 0) {
         serverSubscription.offset = pub.offset;
-        _serverSubs[channel] = serverSubscription; // TODO: necessary to assign explicitly?
       }
     }
   }


### PR DESCRIPTION
## Summary

- Removes a redundant line in `_handlePub` (`lib/src/client.dart`) that re-inserted a `ServerSubscription` into `_serverSubs` under its existing key after updating its `offset`.
- `ServerSubscription` is a mutable class with a non-`final` `offset` field, so `serverSubscription.offset = pub.offset` already mutates the same object instance that the map holds a reference to. The subsequent `_serverSubs[channel] = serverSubscription` was a no-op that just wrote the identical reference back to the same key.
- The line carried a `// TODO: necessary to assign explicitly?` comment; this resolves that question (no, it wasn't necessary) and removes the dead code.

## Test plan

- `docker compose up -d --wait` to start Centrifugo, then `dart run test --reporter expanded` — all 82 tests pass (this path is covered by the server-side publication/recovery tests).
- `dart analyze lib/` — no issues found.