### PR TITLE
Include message in UnauthorizedException.toString()

### DIFF
--- a/lib/src/error.dart
+++ b/lib/src/error.dart
@@ -105,6 +105,6 @@ class UnauthorizedException implements Exception {
 
   @override
   String toString() {
-    return 'UnauthorizedException';
+    return 'UnauthorizedException: $message';
   }
 }

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -1,0 +1,16 @@
+import 'package:centrifuge/centrifuge.dart' as centrifuge;
+import 'package:test/test.dart';
+
+void main() {
+  group('UnauthorizedException', () {
+    test('toString includes the custom message', () {
+      final ex = centrifuge.UnauthorizedException('refresh token expired');
+      expect(ex.toString(), contains('refresh token expired'));
+    });
+
+    test('toString includes the default message', () {
+      final ex = centrifuge.UnauthorizedException();
+      expect(ex.toString(), contains('unauthorized'));
+    });
+  });
+}


### PR DESCRIPTION
## What changed

`UnauthorizedException.toString()` in `lib/src/error.dart` hardcoded the string `'UnauthorizedException'` and ignored the `message` field entirely. Every sibling error class in the same file (`Error`, `TransportError`, `ConnectError`, `RefreshError`, `SubscriptionSubscribeError`, etc.) interpolates its payload into `toString()`; this one didn't.

`UnauthorizedException` accepts a custom `message` — e.g. an app's `getToken` callback can throw `UnauthorizedException('refresh token expired')` to signal a specific auth failure reason. That message was silently dropped whenever the exception got logged or printed, leaving only the generic `UnauthorizedException` with no clue why auth failed.

## Why it's safe

- One-line fix, no API/constructor/field changes.
- Doesn't affect protocol/wire behavior — only human-readable debug output.
- Confirmed all call sites (`lib/src/client.dart`, `lib/src/subscription.dart`) only do `ex is UnauthorizedException` type checks; none parse `.toString()` output.

## Verification

Added `test/error_test.dart` with two cases:
- `UnauthorizedException('refresh token expired').toString()` contains the custom message
- `UnauthorizedException().toString()` contains the default `'unauthorized'` message

Confirmed the regression: stashed the fix and reran — both cases failed, asserting the actual output was the bare `'UnauthorizedException'` string. Restored the fix and reran — both pass.

Also ran the other non-network unit test files (`filter_test.dart`, `compaction_test.dart`, `fossil_test.dart`) to confirm no regressions — all pass. `test/client_test.dart` requires a live Centrifugo instance (via `docker-compose.yml`) and wasn't run since this change doesn't touch any logic it covers (only display text, not used by any connection/auth flow assertion).