### PR TITLE
Fix missing closing brace in MessageEvent.toString()

### DIFF
--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -81,7 +81,7 @@ class MessageEvent {
 
   @override
   String toString() {
-    return 'MessageEvent{data: ${utf8.decode(data, allowMalformed: true)}';
+    return 'MessageEvent{data: ${utf8.decode(data, allowMalformed: true)}}';
   }
 }
 

--- a/test/events_test.dart
+++ b/test/events_test.dart
@@ -1,0 +1,11 @@
+import 'package:centrifuge/centrifuge.dart' as centrifuge;
+import 'package:test/test.dart';
+
+void main() {
+  group('MessageEvent', () {
+    test('toString is well-formed and includes the data', () {
+      final event = centrifuge.MessageEvent('hello'.codeUnits);
+      expect(event.toString(), 'MessageEvent{data: hello}');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `MessageEvent.toString()` in `lib/src/events.dart` was missing the closing `}` for its literal `{...}` wrapper, unlike every other event's `toString()` in the file (e.g. `PublicationEvent`, `ConnectedEvent`). Output looked like `MessageEvent{data: hello` instead of `MessageEvent{data: hello}`.
- Added the missing brace.

## Test plan
- Added `test/events_test.dart` with a regression test asserting `MessageEvent('hello'.codeUnits).toString() == 'MessageEvent{data: hello}'`.
- Verified the test fails against the old code (`Actual: 'MessageEvent{data: hello'`, missing trailing `}`) and passes with the fix.
- Ran `dart test test/events_test.dart test/fossil_test.dart test/filter_test.dart test/error_test.dart` — all pass. These cover the touched code plus adjacent pure-logic suites; `client_test.dart`/`compaction_test.dart` require a live Centrifugo instance and are unaffected by this change (a `toString()`-only fix with no protocol/networking impact).
- `dart analyze` shows only pre-existing issues in `example/` apps and existing test files, none introduced by this change.