### PR TITLE
Guard subscription token refresh timer when getToken is unset

### DIFF
--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -329,6 +329,9 @@ class SubscriptionImpl implements Subscription {
   void _addSubscribing(SubscribingEvent event) => _subscribingController.add(event);
 
   void _refreshToken() async {
+    if (_config.getToken == null) {
+      return;
+    }
     try {
       final event = SubscriptionTokenEvent(channel);
       final String token = await _config.getToken!(event);

--- a/test/subscription_refresh_test.dart
+++ b/test/subscription_refresh_test.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:centrifuge/centrifuge.dart' as centrifuge;
+import 'package:centrifuge/src/proto/client.pb.dart' as protocol;
+import 'package:test/test.dart';
+
+import 'fake_server.dart';
+
+// Regression test: a subscription can be marked as `expires` by the server
+// without the app ever configuring a `SubscriptionConfig.getToken` callback
+// (e.g. a static, non-expiring subscription token combined with a server
+// that still reports a TTL). The refresh timer must not attempt to call a
+// missing callback.
+
+void main() {
+  group('Subscription token refresh without getToken callback', () {
+    late FakeCentrifugoServer server;
+    late centrifuge.Client client;
+
+    setUp(() async {
+      server = FakeCentrifugoServer();
+      await server.start();
+      server.onSubscribe = (channel, req) => protocol.SubscribeResult()
+        ..expires = true
+        ..ttl = 1;
+      client = centrifuge.createClient(server.url, centrifuge.ClientConfig());
+    });
+
+    tearDown(() async {
+      await client.close();
+      await server.stop();
+    });
+
+    test('refresh timer does not crash or emit errors when getToken is unset', () async {
+      await client.connect();
+
+      final sub = client.newSubscription('news');
+      final errors = <centrifuge.SubscriptionErrorEvent>[];
+      final errorSubscription = sub.error.listen(errors.add);
+      addTearDown(() => errorSubscription.cancel());
+
+      await sub.subscribe();
+
+      // Wait past the 1-second TTL for the refresh timer to fire.
+      await Future<void>.delayed(const Duration(milliseconds: 1300));
+
+      expect(errors, isEmpty);
+      expect(sub.state, centrifuge.SubscriptionState.subscribed);
+      expect(server.received.any((cmd) => cmd.hasSubRefresh()), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What

`SubscriptionImpl._refreshToken()` force-unwraps `SubscriptionConfig.getToken`
(`_config.getToken!(event)`) without checking it for null first. The
connection-level counterpart, `ClientImpl._refreshToken()`, already guards
this (`if (_config.getToken == null) return;`) — the subscription-level
version was missing the equivalent guard.

## Why

`SubscriptionConfig.getToken` is optional — a subscription can be created
with just a static `token` and no refresh callback. If the server still
reports `expires: true`/a `ttl` on the subscribe (or sub-refresh) result, the
refresh timer fires `_refreshToken()`, which throws a null-check
`TypeError`. That throw is caught by the surrounding `try/catch`, so it isn't
a hard crash, but it's treated like any other refresh failure: it emits a
`SubscriptionErrorEvent` with a confusing "Null check operator used on a null
value" message and reschedules itself every 5-10s — forever. The
client-level refresh instead does nothing in this situation, which is the
correct behavior since there's nothing to refresh.

## Fix

Add the same early-return guard used in `ClientImpl._refreshToken()` to
`SubscriptionImpl._refreshToken()`.

## Test plan

Added `test/subscription_refresh_test.dart`, using the existing
`FakeCentrifugoServer` test helper:

- Server replies to `Subscribe` with `expires: true, ttl: 1`.
- Client subscribes with no `getToken` configured anywhere (client or
  subscription level).
- After the 1s TTL elapses (timer fires), asserts: no `SubscriptionErrorEvent`
  was emitted, the subscription is still in `subscribed` state, and no
  `SubRefresh` command was ever sent to the server.

Verified the test reproduces the bug: with the guard removed, the test fails
with the exact `SubscriptionErrorEvent` / null-check `TypeError` described
above; with the guard in place, it passes. Ran the full suite (`dart test`,
against docker-compose Centrifugo + the fake server) — all 86 tests pass —
and `dart analyze`, which reports only pre-existing issues unrelated to this
change (example apps and existing test files).