### PR TITLE
Reset server-side subscription recovery position on state invalidation

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -5,6 +5,7 @@ import 'package:centrifuge/centrifuge.dart';
 import 'package:centrifuge/src/codes.dart';
 import 'package:centrifuge/src/server_subscription.dart';
 import 'package:centrifuge/src/transport.dart';
+import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:meta/meta.dart';
 
 import 'platform/vm.dart' if (dart.library.js_interop) 'platform/js.dart';
@@ -397,6 +398,15 @@ class ClientImpl implements Client {
       _refreshRequired = true;
       for (final s in _subscriptions.values) {
         s.invalidateState();
+      }
+      // Server-side subscriptions aren't tracked by SubscriptionImpl, but their
+      // cached recovery position must be invalidated too - otherwise the next
+      // connect request keeps asking the server to recover from the now-stale
+      // pre-invalidation offset/epoch, defeating the point of state invalidation.
+      // The recoverable flag is left untouched, matching invalidateState() above.
+      for (final s in _serverSubs.values) {
+        s.offset = $fixnum.Int64(0);
+        s.epoch = '_';
       }
     }
     _reconnectTimer?.cancel();

--- a/test/server_subscription_invalidation_test.dart
+++ b/test/server_subscription_invalidation_test.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:centrifuge/centrifuge.dart' as centrifuge;
+import 'package:centrifuge/src/proto/client.pb.dart' as protocol;
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+import 'fake_server.dart';
+
+// Regression test: on disconnect code 3014 ("state invalidated"), the client
+// resets each CLIENT-SIDE subscription's cached recovery position (offset 0,
+// epoch "_") so the next resubscribe can't recover from now-invalid state.
+// SERVER-SIDE subscriptions (pushed by the server via the Connect reply's
+// `subs` field) must get the same treatment — otherwise the connect request
+// keeps asking the server to recover from the stale pre-invalidation offset
+// and epoch on every reconnect, defeating the point of state invalidation.
+// Mirrors centrifugal/centrifuge-swift#135 and centrifugal/centrifuge-js#385.
+//
+// This uses the in-process FakeCentrifugoServer (rather than the docker-compose
+// OSS server used by client_test.dart) so the test can inspect the raw Connect
+// command the client sends on reconnect — including the offset/epoch it
+// carries for the server-side sub — which isn't observable via the public API.
+
+Future<T> _waitForEvent<T>(Stream<T> stream, {Duration timeout = const Duration(seconds: 5)}) {
+  return stream.first.timeout(timeout);
+}
+
+void main() {
+  group('Server-side subscription state invalidation', () {
+    late FakeCentrifugoServer server;
+    late centrifuge.Client client;
+
+    setUp(() async {
+      server = FakeCentrifugoServer();
+      await server.start();
+      server.connectResult = protocol.ConnectResult()
+        ..client = 'fake-client'
+        ..version = '0.0.0'
+        ..ping = 25
+        ..subs['news'] = (protocol.SubscribeResult()
+          ..recoverable = true
+          ..offset = Int64(42)
+          ..epoch = 'epoch1');
+      client = centrifuge.createClient(
+        server.url,
+        centrifuge.ClientConfig(minReconnectDelay: const Duration(milliseconds: 1)),
+      );
+    });
+
+    tearDown(() async {
+      await client.close();
+      await server.stop();
+    });
+
+    test('3014 disconnect resets cached offset/epoch but keeps recoverable', () async {
+      final firstSubscribed = _waitForEvent<centrifuge.ServerSubscribedEvent>(client.subscribed);
+      await client.connect();
+      final subscribedEvent = await firstSubscribed;
+      expect(subscribedEvent.channel, 'news');
+      expect(subscribedEvent.recoverable, isTrue);
+      expect(subscribedEvent.streamPosition?.offset, Int64(42));
+      expect(subscribedEvent.streamPosition?.epoch, 'epoch1');
+
+      // Only one Connect so far, and it carries no subs (nothing cached yet
+      // on the very first connect).
+      final firstConnect = server.received.singleWhere((cmd) => cmd.hasConnect()).connect;
+      expect(firstConnect.subs.containsKey('news'), isFalse);
+
+      // Server-initiated disconnect with code 3014 forces an automatic
+      // reconnect (3014 < 3500).
+      final reconnected = _waitForEvent<centrifuge.ConnectedEvent>(client.connected);
+      server.disconnect(3014, 'invalidated');
+      await reconnected;
+
+      // The reconnect's Connect command must carry the server-side sub's
+      // recovery params reset to the sentinel — not the stale offset=42,
+      // epoch='epoch1' cached from before invalidation.
+      final connectCommands = server.received.where((cmd) => cmd.hasConnect()).toList();
+      expect(connectCommands, hasLength(2),
+          reason: 'expected exactly one reconnect after the 3014 kick');
+      final secondConnect = connectCommands[1].connect;
+      expect(secondConnect.subs.containsKey('news'), isTrue);
+      final resent = secondConnect.subs['news']!;
+      expect(resent.offset, Int64(0),
+          reason: 'offset must be reset to the unrecoverable sentinel after state invalidation');
+      expect(resent.epoch, '_',
+          reason: 'epoch must be reset to the unrecoverable sentinel after state invalidation');
+      expect(resent.recover, isTrue,
+          reason: 'the recoverable flag itself must be left untouched');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

On disconnect code 3014 ("state invalidated"), the client already resets each CLIENT-SIDE subscription's cached recovery position (offset 0, epoch `"_"`) so the next resubscribe can't recover from now-invalid state (see `SubscriptionImpl.invalidateState()` / `lib/src/subscription.dart`).

However, SERVER-SIDE subscriptions — those pushed by the server via the Connect reply's `subs` field and tracked in `_serverSubs` (`lib/src/client.dart`) — were left untouched. The connect request unconditionally sends each server-side sub's cached offset/epoch as recovery params on every reconnect (`ConnectRequest.subs`), so an app relying only on server-side subscriptions kept requesting recovery from the stale pre-invalidation position after a 3014 disconnect, defeating the entire point of state invalidation.

This mirrors a bug already fixed in the sibling SDKs:
- centrifugal/centrifuge-swift#135
- centrifugal/centrifuge-js#385

## Fix

In `_processDisconnect`'s code-3014 handling in `lib/src/client.dart`, after invalidating client-side subscriptions, also reset every entry in `_serverSubs`:

```dart
for (final s in _serverSubs.values) {
  s.offset = $fixnum.Int64(0);
  s.epoch = '_';
}
```

The `recoverable` flag is left untouched, matching exactly what `invalidateState()` already does for client-side subscriptions.

## Test plan

- [x] Added `test/server_subscription_invalidation_test.dart`, a regression test using the in-process `FakeCentrifugoServer`. It seeds a server-side subscription with a known recoverable offset/epoch, triggers a 3014 disconnect, and asserts the *next Connect command sent on reconnect* carries the reset sentinel (offset 0, epoch `"_"`) while `recover` stays `true`. (Verifying this requires inspecting the raw wire command since offset/epoch aren't exposed on the public API — the fake server exists in this repo for exactly this kind of scenario.)
- [x] Verified the new test fails against the pre-fix code (offset stays at the stale cached value) and passes with the fix.
- [x] `dart analyze lib/ test/` — clean.
- [x] `dart run test` (full suite, including docker-compose Centrifugo integration tests) — all passing.