### PR TITLE
Treat an empty token from getToken during refresh as unauthorized

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -715,10 +715,10 @@ class ClientImpl implements Client {
     if (_config.getToken == null) {
       return;
     }
+    final String token;
     try {
       final event = ConnectionTokenEvent();
-      final String token = await _config.getToken!(event);
-      _token = token;
+      token = await _config.getToken!(event);
     } catch (ex) {
       if (state != State.connected) {
         return;
@@ -741,12 +741,17 @@ class ClientImpl implements Client {
     if (state != State.connected) {
       return;
     }
-
-    final request = protocol.RefreshRequest();
-
-    if (_token != '') {
-      request.token = _token;
+    if (token == '') {
+      // An empty token from getToken during refresh means the user is not
+      // authenticated anymore, so disconnect instead of sending a token-less
+      // RefreshRequest. Note this only applies to refresh - an empty token on
+      // the initial connect still means "connect as anonymous".
+      await _failUnauthorized();
+      return;
     }
+    _token = token;
+
+    final request = protocol.RefreshRequest()..token = _token;
 
     try {
       final result = await _transport!.sendMessage(

--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -332,10 +332,10 @@ class SubscriptionImpl implements Subscription {
     if (_config.getToken == null) {
       return;
     }
+    final String token;
     try {
       final event = SubscriptionTokenEvent(channel);
-      final String token = await _config.getToken!(event);
-      _token = token;
+      token = await _config.getToken!(event);
     } catch (ex) {
       if (state != SubscriptionState.subscribed) {
         return;
@@ -354,6 +354,20 @@ class SubscriptionImpl implements Subscription {
       });
       return;
     }
+
+    if (state != SubscriptionState.subscribed) {
+      // unsubscribe() or a disconnect arrived while getToken was in flight.
+      return;
+    }
+    if (token == '') {
+      // Documented contract: an empty token means the user has no permission
+      // to stay in the channel anymore, so unsubscribe instead of sending a
+      // token-less SubRefreshRequest. The stored token is deliberately kept
+      // untouched - the subscription is going away.
+      _failUnauthorized();
+      return;
+    }
+    _token = token;
 
     try {
       final request = protocol.SubRefreshRequest()

--- a/test/empty_token_refresh_test.dart
+++ b/test/empty_token_refresh_test.dart
@@ -1,0 +1,121 @@
+import 'dart:async';
+
+import 'package:centrifuge/centrifuge.dart' as centrifuge;
+import 'package:centrifuge/src/proto/client.pb.dart' as protocol;
+import 'package:test/test.dart';
+
+import 'fake_server.dart';
+
+// An empty string returned by a getToken callback during a *refresh* is the
+// documented way for an app to say "this user is not allowed here anymore"
+// (see https://centrifugal.dev/docs/transports/client_api). The SDK must then
+// unsubscribe / disconnect with the unauthorized code instead of sending a
+// token-less Refresh / SubRefresh command to the server.
+//
+// Note this only applies to refreshes: an empty token on the *initial* connect
+// still means "connect as an anonymous user".
+
+void main() {
+  group('Subscription token refresh returning an empty token', () {
+    late FakeCentrifugoServer server;
+    late centrifuge.Client client;
+
+    setUp(() async {
+      server = FakeCentrifugoServer();
+      await server.start();
+      server.onSubscribe = (channel, req) => protocol.SubscribeResult()
+        ..expires = true
+        ..ttl = 1;
+      client = centrifuge.createClient(server.url, centrifuge.ClientConfig());
+    });
+
+    tearDown(() async {
+      await client.close();
+      await server.stop();
+    });
+
+    test('unsubscribes with the unauthorized code instead of sending SubRefresh', () async {
+      await client.connect();
+
+      var getTokenCalls = 0;
+      final sub = client.newSubscription(
+        'news',
+        centrifuge.SubscriptionConfig(getToken: (event) async {
+          getTokenCalls++;
+          // Real token for the initial subscribe, empty one on refresh.
+          return getTokenCalls == 1 ? 'sub-token' : '';
+        }),
+      );
+
+      final unsubscribes = <centrifuge.UnsubscribedEvent>[];
+      final unsubscribedSubscription = sub.unsubscribed.listen(unsubscribes.add);
+      addTearDown(() => unsubscribedSubscription.cancel());
+
+      await sub.subscribe();
+      expect(sub.state, centrifuge.SubscriptionState.subscribed);
+
+      // Wait past the 1-second TTL for the refresh timer to fire.
+      await Future<void>.delayed(const Duration(milliseconds: 1300));
+
+      expect(getTokenCalls, 2);
+      expect(sub.state, centrifuge.SubscriptionState.unsubscribed);
+      expect(unsubscribes, hasLength(1));
+      expect(unsubscribes.single.code, 1); // unsubscribedCodeUnauthorized
+      expect(unsubscribes.single.reason, 'unauthorized');
+      expect(server.received.any((cmd) => cmd.hasSubRefresh()), isFalse);
+    });
+  });
+
+  group('Connection token refresh returning an empty token', () {
+    late FakeCentrifugoServer server;
+    late centrifuge.Client client;
+
+    setUp(() async {
+      server = FakeCentrifugoServer();
+      await server.start();
+      server.connectResult = protocol.ConnectResult()
+        ..client = 'fake-client'
+        ..version = '0.0.0'
+        ..ping = 25
+        ..expires = true
+        ..ttl = 1;
+    });
+
+    tearDown(() async {
+      await client.close();
+      await server.stop();
+    });
+
+    test('disconnects with the unauthorized code instead of sending Refresh', () async {
+      var getTokenCalls = 0;
+      client = centrifuge.createClient(
+        server.url,
+        // Initial token is set, so getToken is only called by the refresh timer.
+        centrifuge.ClientConfig(
+          token: 'initial-token',
+          getToken: (event) async {
+            getTokenCalls++;
+            return '';
+          },
+        ),
+      );
+
+      final disconnects = <centrifuge.DisconnectedEvent>[];
+      final disconnectedSubscription = client.disconnected.listen(disconnects.add);
+      addTearDown(() => disconnectedSubscription.cancel());
+
+      await client.connect();
+      expect(client.state, centrifuge.State.connected);
+
+      // Wait past the 1-second TTL for the refresh timer to fire.
+      await Future<void>.delayed(const Duration(milliseconds: 1300));
+
+      expect(getTokenCalls, 1);
+      expect(client.state, centrifuge.State.disconnected);
+      expect(disconnects, hasLength(1));
+      expect(disconnects.single.code, 1); // disconnectedCodeUnauthorized
+      expect(disconnects.single.reason, 'unauthorized');
+      expect(server.received.any((cmd) => cmd.hasRefresh()), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What

An empty string returned by a `getToken` callback during a token **refresh** is the documented way for an application to say "this user is not allowed here anymore":

> If your callback returns an empty string – this means the user has no permission to subscribe to a channel anymore and the subscription will be unsubscribed.
> — [client_api.md](https://centrifugal.dev/docs/transports/client_api)

Neither refresh path in this SDK honoured that. Both stored the empty token and then sent a token-less `Refresh` / `SubRefresh` command to the server. Instead of a clean unsubscribe/disconnect with the unauthorized code, the app got whatever the server made of a refresh with no token — and at the subscription level, an indefinite retry loop rather than a terminal `UnsubscribedEvent`.

This matches the handling to `centrifuge-js`, which does exactly this in both places ([`_refresh()`](https://github.com/centrifugal/centrifuge-js/blob/master/src/centrifuge.ts) and [`Subscription._refresh()`](https://github.com/centrifugal/centrifuge-js/blob/master/src/subscription.ts)):

- `SubscriptionImpl._refreshToken` — an empty token calls `_failUnauthorized()`, unsubscribing with code `1` / `"unauthorized"`.
- `ClientImpl._refreshToken` — an empty token calls `_failUnauthorized()`, disconnecting with code `1` / `"unauthorized"`.

The token is now only stored once it is known to be non-empty, so a rejected refresh no longer wipes the token still in use.

This applies to **refreshes only**. An empty token on the initial connect still means "connect as an anonymous user", matching both the docs and `centrifuge-js`. Anonymous connections have no token-driven expiry, so the refresh timer that leads here is not scheduled for them.

Also adds the state guard that was missing on the subscription refresh success path: if `unsubscribe()` or a disconnect arrives while `getToken` is in flight, the `SubRefresh` is no longer sent. The connection-level path already had the equivalent `state != State.connected` check.

No public API change.

## Verification

Added `test/empty_token_refresh_test.dart`, two tests driven by the existing in-process `FakeCentrifugoServer`:

1. **Subscription** — server replies to subscribe with `expires: true, ttl: 1`. `getToken` returns a real token on the initial subscribe and `''` on the refresh. Asserts `getToken` was called twice, the subscription ends up `unsubscribed`, exactly one `UnsubscribedEvent(1, 'unauthorized')` was emitted, and no `SubRefresh` command reached the server.
2. **Connection** — `ConnectResult` carries `expires: true, ttl: 1`, and an initial `token` is configured so `getToken` is only reached by the refresh timer, where it returns `''`. Asserts the client ends up `disconnected`, exactly one `DisconnectedEvent(1, 'unauthorized')` was emitted, and no `Refresh` command reached the server.

Against the unpatched code both fail on the state assertion — the subscription stayed `subscribed` and the client stayed `connected`, because the token-less refresh was sent and accepted. Both pass with the fix.

Keeping both tests in the tree: they pin documented cross-SDK protocol semantics through the public API and the fake server, with no coupling to internals, and nothing else covers the empty-token branch.

Also ran, with Centrifugo up via `docker compose up -d --wait`:

- `dart analyze lib/` — clean (what CI runs).
- `dart test` — full suite, **89/89 passing**. (`dart analyze test/` reports 5 pre-existing `prefer_is_empty` infos in `client_test.dart`, untouched by this change and not part of the CI analyze step.)