### PR TITLE
Drop the channel compaction ID when a subscription moves to subscribing

### DIFF
--- a/lib/src/subscription.dart
+++ b/lib/src/subscription.dart
@@ -637,6 +637,14 @@ class SubscriptionImpl implements Subscription {
       return;
     }
     _clearSubscribedState();
+    // Channel compaction: the numeric channel ID is scoped to the server-side
+    // subscription that just went away, so drop it here too — not only in
+    // moveToUnsubscribed. Matters for a temporary server-initiated unsubscribe
+    // (code >= 2500), where the connection stays up and the ID registry is not
+    // cleared: without this, a push carrying the freed ID would still be routed
+    // to this subscription while it is only Subscribing. The next subscribe
+    // reply re-establishes the ID (the server may reuse the same one).
+    _setPushId(0);
     state = SubscriptionState.subscribing;
     final event = SubscribingEvent(code, reason);
     _addSubscribing(event);

--- a/test/compaction_test.dart
+++ b/test/compaction_test.dart
@@ -25,6 +25,8 @@ void main() {
     var channelId = 42;
 
     setUp(() async {
+      // Reset between tests — one of them reassigns the id mid-test.
+      channelId = 42;
       server = FakeCentrifugoServer();
       await server.start();
       // Negotiate channel compaction: assign a numeric channel id whenever the
@@ -148,6 +150,55 @@ void main() {
       }
       expect(received, hasLength(1));
       expect(jsonDecode(utf8.decode(received.first.data)), {'fresh': true});
+    });
+
+    test('id mapping is dropped on temporary server-side unsubscribe', () async {
+      // Regression test: a server-initiated unsubscribe with code >= 2500 tears
+      // down the server-side subscription and moves the client-side one back to
+      // Subscribing while the connection stays up — so, unlike a reconnect, the
+      // client does not clear its whole ID registry. The numeric channel ID is
+      // scoped to the subscription that just went away and the server is free to
+      // hand it to another channel, so it must stop routing to this
+      // subscription until a new subscribe reply re-establishes it.
+      // Mirrors centrifugal/centrifuge-js#364.
+      await client.connect();
+
+      // Keep the subscription in Subscribing after the kick: the resubscribe is
+      // answered with a temporary error and the retry is pushed far out, so the
+      // stale registration is observable instead of being immediately
+      // overwritten by a successful resubscribe reply.
+      final sub = client.newSubscription(
+        'compacted-channel',
+        centrifuge.SubscriptionConfig(
+          minResubscribeDelay: const Duration(seconds: 30),
+          maxResubscribeDelay: const Duration(seconds: 30),
+        ),
+      );
+      await sub.subscribe();
+
+      final received = <centrifuge.PublicationEvent>[];
+      final pubSubscription = sub.publication.listen(received.add);
+      addTearDown(() => pubSubscription.cancel());
+
+      server.onCommand = (cmd) {
+        if (!cmd.hasSubscribe()) return null;
+        return protocol.Reply()
+          ..id = cmd.id
+          ..error = (protocol.Error()
+            ..code = 100
+            ..message = 'temporary'
+            ..temporary = true);
+      };
+
+      final subscribing = _waitForEvent<centrifuge.SubscribingEvent>(sub.subscribing);
+      server.unsubscribe('compacted-channel', 2500, 'insufficient state');
+      await subscribing;
+      expect(sub.state, centrifuge.SubscriptionState.subscribing);
+
+      // A push carrying the now-freed ID must not reach this subscription.
+      server.publish(id: 42, data: utf8.encode('{"stale":true}'));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      expect(received, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## What

`SubscriptionImpl.moveToSubscribing()` now clears the subscription's channel-compaction ID (`_setPushId(0)`), the same way `close()`, `moveToUnsubscribed()` and `invalidateState()` already do.

## Why

With channel compaction the server assigns a numeric channel ID in the subscribe reply, and the client routes ID-carrying pushes through `ClientImpl._subscriptionsById`. That ID is scoped to the server-side subscription, so it has to be dropped whenever that subscription goes away.

Three of the four exit paths did this. `moveToSubscribing()` did not, which matters for a **temporary server-initiated unsubscribe** (code >= 2500 — `UnsubscribeCodeInsufficient` 2500, `UnsubscribeCodeExpired` 2501). There the connection stays up, so — unlike a reconnect, where `_processDisconnect` clears the whole registry — nothing else removes the mapping. The subscription moved back to `subscribing` while still registered under an ID the server had already freed and is free to reassign to another channel. Pushes carrying that ID kept being delivered to a subscription the server had torn down, and `handlePublication` advanced its recovery offset from data it should never have received — corrupting the position used by the pending resubscribe.

(Code 2502 happened to be safe already, since `_handleUnsubscribe` calls `invalidateState()` first, which clears the ID. So the behaviour was inconsistent between 2500/2501 and 2502 even though the server tears the subscription down identically in all three cases.)

centrifuge-js clears the equivalent `_id` field in `_setSubscribing()` for exactly this reason (centrifugal/centrifuge-js#364, which also added the `_id = 0` in `_setUnsubscribed` that was ported here). This is the one site that was missed when compaction landed in #111.

No public API change.

## Validating test

Added `id mapping is dropped on temporary server-side unsubscribe` to `test/compaction_test.dart` (in-process `FakeCentrifugoServer`, since compaction is a Centrifugo PRO feature and can't be exercised against the OSS docker-compose server):

1. Negotiates channel ID 42 and subscribes.
2. Sends an `Unsubscribe` push with code 2500.
3. Holds the subscription in `subscribing` by answering the resubscribe with a temporary error and configuring a long resubscribe delay — otherwise a successful resubscribe reply would immediately overwrite the mapping and hide the stale registration.
4. Pushes a publication carrying ID 42 and asserts nothing is delivered.

Against the unfixed code it fails with the stale publication delivered:

```
Expected: empty
  Actual: [PublicationEvent{data: {"stale":true}, offset: 0, info: null}]
```

With the fix it passes. Kept in the tree: it guards a real routing-correctness invariant, matches the existing compaction test suite in style, and only touches the public event API plus the fake server's protocol-level hooks.

Also reset the shared `channelId` in `setUp` — one existing test reassigns it mid-test, so the later tests were relying on execution order.

## Verification

- Full suite against the docker-compose Centrifugo: 90 tests, all passing.
- `dart analyze lib/` (what CI runs): no issues.